### PR TITLE
Update CNAME to `play.ballerina.io`

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-playground.ballerina.io
+play.ballerina.io


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request updates the repository's CNAME configuration to point to `play.ballerina.io` instead of `playground.ballerina.io`. This is a straightforward domain name update with minimal impact, affecting only a single line in the CNAME file.

## Changes

- Updated CNAME domain to reflect the new canonical domain for the Ballerina playground service

## Impact

This change enables the repository to be accessible via the new domain `play.ballerina.io`, streamlining the naming convention for the Ballerina playground service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->