### PR TITLE
Fix Github link and Add WASM loading progress bar

### DIFF
--- a/web/src/components/editor.tsx
+++ b/web/src/components/editor.tsx
@@ -35,10 +35,21 @@ function WasmLoadingScreen({ progress }: { progress: number }) {
     return (
         <div className="w-full flex items-center justify-center min-h-dvh">
             <div className="flex flex-col items-center gap-3">
-                <div className="text-sm text-muted-foreground">
+                <div
+                    id="wasm-load-progress-label"
+                    className="text-sm text-muted-foreground"
+                    aria-live="polite"
+                >
                     Loading WASM binaries... {pct}%
                 </div>
-                <div className="w-48 h-1.5 rounded-full bg-muted overflow-hidden">
+                <div
+                    className="w-48 h-1.5 rounded-full bg-muted overflow-hidden"
+                    role="progressbar"
+                    aria-labelledby="wasm-load-progress-label"
+                    aria-valuenow={pct}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                >
                     <div
                         className="h-full bg-emerald-500 transition-[width] duration-150"
                         style={{ width: `${pct}%` }}

--- a/web/src/components/editor.tsx
+++ b/web/src/components/editor.tsx
@@ -177,7 +177,7 @@ function EditorHeader() {
             <div>
                 <a
                     className="flex items-center gap-2 text-xs text-muted-foreground hover:text-secondary-foreground"
-                    href="https://github.com/ballerina-platform/ballerina-lang-go"
+                    href="https://github.com/ballerina-platform/playground"
                     target="_blank"
                     rel="noopener noreferrer"
                 >

--- a/web/src/components/editor.tsx
+++ b/web/src/components/editor.tsx
@@ -30,6 +30,25 @@ import { cn } from "@/lib/utils";
 
 import type { FilePath } from "@/types/files";
 
+function WasmLoadingScreen({ progress }: { progress: number }) {
+    const pct = Math.max(0, Math.min(100, progress));
+    return (
+        <div className="w-full flex items-center justify-center min-h-dvh">
+            <div className="flex flex-col items-center gap-3">
+                <div className="text-sm text-muted-foreground">
+                    Loading WASM binaries... {pct}%
+                </div>
+                <div className="w-48 h-1.5 rounded-full bg-muted overflow-hidden">
+                    <div
+                        className="h-full bg-emerald-500 transition-[width] duration-150"
+                        style={{ width: `${pct}%` }}
+                    />
+                </div>
+            </div>
+        </div>
+    );
+}
+
 function getLanguage(path: FilePath): string {
     const ext = path.split(".").pop();
     switch (ext) {
@@ -175,7 +194,7 @@ function EditorHeader() {
 }
 
 function EditorContent() {
-    const { isReady, run, updateFile } = useBallerina();
+    const { isReady, progress, run, updateFile } = useBallerina();
 
     const openOutputWith = useEditorStore((s) => s.openOutputWith);
 
@@ -230,13 +249,7 @@ function EditorContent() {
     );
 
     if (!isReady) {
-        return (
-            <div className="w-full flex items-center justify-center min-h-dvh">
-                <div className="text-sm text-muted-foreground">
-                    Loading WASM binaries...
-                </div>
-            </div>
-        );
+        return <WasmLoadingScreen progress={progress ?? 0} />;
     }
 
     return (

--- a/web/src/hooks/use-ballerina.ts
+++ b/web/src/hooks/use-ballerina.ts
@@ -4,18 +4,58 @@ import * as React from "react";
 
 export function useBallerina() {
     const [isReady, setIsReady] = React.useState(false);
+    const [progress, setProgress] = React.useState(0);
 
     React.useEffect(() => {
         let cancelled = false;
 
         async function load() {
             const go = new window.Go();
-            const result = await WebAssembly.instantiateStreaming(
-                fetch("ballerina.wasm"),
-                go.importObject,
-            );
+            const res = await fetch("ballerina.wasm");
+            const total = Number(res.headers.get("content-length") ?? 0);
+
+            if (!res.body || !total) {
+                const result = await WebAssembly.instantiateStreaming(
+                    res,
+                    go.importObject,
+                );
+                go.run(result.instance);
+                if (!cancelled) {
+                    setProgress(100);
+                    setIsReady(true);
+                }
+                return;
+            }
+
+            const reader = res.body.getReader();
+            let loaded = 0;
+            const chunks: Uint8Array[] = [];
+
+            for (;;) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                if (value) {
+                    chunks.push(value);
+                    loaded += value.byteLength;
+                    if (!cancelled && total) {
+                        setProgress(Math.round((loaded / total) * 100));
+                    }
+                }
+            }
+
+            const bytes = new Uint8Array(loaded);
+            let offset = 0;
+            for (const chunk of chunks) {
+                bytes.set(chunk, offset);
+                offset += chunk.byteLength;
+            }
+
+            const result = await WebAssembly.instantiate(bytes, go.importObject);
             go.run(result.instance);
-            if (!cancelled) setIsReady(true);
+            if (!cancelled) {
+                setProgress(100);
+                setIsReady(true);
+            }
         }
 
         load().catch(() => {
@@ -52,5 +92,5 @@ export function useBallerina() {
         return null;
     }
 
-    return { isReady, updateFile, run };
+    return { isReady, progress, updateFile, run };
 }


### PR DESCRIPTION
## Purpose
$Subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This pull request improves the WASM initialization experience in the playground editor by adding real-time loading progress and a dedicated UI.

Changes

- UX: Adds a WasmLoadingScreen component that displays a progress bar and percentage message while the WebAssembly runtime is loading, replacing the previous inline loading UI. (web/src/components/editor.tsx)
- Loading behavior: Extends the useBallerina hook to track and expose loading progress. The loader attempts chunked streaming of the wasm payload to compute progress when content-length is available and falls back to streaming instantiation otherwise. Progress is updated during download and set to 100% when initialization completes. (web/src/hooks/use-ballerina.ts)
- API: useBallerina() now returns a progress value in addition to isReady, updateFile, and run.
- Minor: Updates the GitHub link in the editor header to point to the playground repository.

Files modified
- web/src/components/editor.tsx (+/– changes)
- web/src/hooks/use-ballerina.ts (+/– changes)

Intent
- Improve user feedback during WASM initialization and make loading state observable to UI components to enhance perceived responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->