### PR TITLE
Improve README and source repo url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ballerina Playground
 
-Ballerina playground is a web based tool which allows trying out language features.
+Ballerina playground is a web based tool for trying out language features, hosted at https://play.ballerina.io/, with the native Ballerina interpreter source at https://github.com/ballerina-platform/ballerina-lang-go.
 
 ## Getting started
 

--- a/web/src/components/editor.tsx
+++ b/web/src/components/editor.tsx
@@ -158,7 +158,7 @@ function EditorHeader() {
             <div>
                 <a
                     className="flex items-center gap-2 text-xs text-muted-foreground hover:text-secondary-foreground"
-                    href="https://github.com/ballerina-platform/ballerina-lang-go"
+                    href="https://github.com/ballerina-platform/playground"
                     target="_blank"
                     rel="noopener noreferrer"
                 >


### PR DESCRIPTION
## Purpose
> Improve README and source repo url

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request improves documentation accuracy and repository references within the Ballerina Playground project.

### Changes Made

**README.md:**
- Enhanced the project description to provide more precise information, including the playground's hosting location at https://play.ballerina.io/ and clarifying the native interpreter source repository as https://github.com/ballerina-platform/ballerina-lang-go

**web/src/components/editor.tsx:**
- Corrected the GitHub link in the EditorHeader component to reference the correct playground repository (https://github.com/ballerina-platform/playground) instead of the interpreter repository

### Intent

These changes improve clarity by ensuring documentation and UI elements accurately direct users to the appropriate repository resources—distinguishing between the playground project itself and its underlying interpreter implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->