### PR TITLE
Bump GitHub Actions workflow dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.26"
           cache: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Set up Go 
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.26"
           cache: true


### PR DESCRIPTION
## Purpose
$subject
Resolves #11

Two actions don't yet have a released version with Node 24 support:
- `actions/upload-pages-artifact` — tracked in actions/upload-pages-artifact#139
- `actions/deploy-pages` — tracked in actions/deploy-pages#409


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes Overview

This pull request updates GitHub Actions workflow dependencies across the project's CI/CD pipelines to address the deprecation of Node 20 on GitHub Actions runners and enable Node 24 compatibility.

## Workflow Updates

### Modified Files
- `.github/workflows/ci.yml`
- `.github/workflows/deploy.yml`

### Dependency Updates
- `actions/checkout`: upgraded from `v4` to `v6`
- `actions/setup-go`: upgraded from `v5` to `v6`

These version upgrades ensure that the workflow actions are compatible with Node 24 while maintaining all existing configuration settings and build parameters.

## Known Limitations

Two upstream GitHub Actions currently lack released versions with Node 24 support and remain unchanged pending upstream releases:
- `actions/upload-pages-artifact` (issue tracked at actions/upload-pages-artifact#139)
- `actions/deploy-pages` (issue tracked at actions/deploy-pages#409)

These dependencies will be updated in a follow-up once the upstream projects publish compatible releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->