### PR TITLE
Fix diagnostic snippet source path resolution

### DIFF
--- a/apps/web/src/stores/file-tree-store.ts
+++ b/apps/web/src/stores/file-tree-store.ts
@@ -300,12 +300,16 @@ export const useFileTreeStore = create<FileTreeState & FileTreeActions>()(
 				root: FileNode,
 				openRelativePath?: string | null,
 			): { loaded: boolean; openPath: string | null } {
-				const openPath = _fs().graftSharedTree(root, openRelativePath);
-				set((s) => {
-					s.tempTree = _fs().tempTree();
-					s.localTree = _fs().localTree();
-				});
-				return { loaded: true, openPath };
+				try {
+					const openPath = _fs().graftSharedTree(root, openRelativePath);
+					set((s) => {
+						s.tempTree = _fs().tempTree();
+						s.localTree = _fs().localTree();
+					});
+					return { loaded: true, openPath };
+				} catch (e) {
+					return { loaded: false, openPath: null };
+				}
 			},
 		};
 	}),

--- a/packages/wasm/diagnostics_printer.go
+++ b/packages/wasm/diagnostics_printer.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"path"
 	"strings"
 )
 
@@ -115,8 +116,19 @@ func printDiagnosticLocation(w io.Writer, s outputStyle, loc diagnosticLocation)
 	}
 }
 
+func snippetSourcePath(fsys fs.FS, projectOrFilePath, diagFile string) string {
+	if projectOrFilePath == "" {
+		return diagFile
+	}
+	info, err := fs.Stat(fsys, projectOrFilePath)
+	if err == nil && !info.IsDir() {
+		return projectOrFilePath
+	}
+	return path.Join(projectOrFilePath, diagFile)
+}
+
 func printSourceSnippet(w io.Writer, s outputStyle, loc diagnosticLocation, fsys fs.FS, severityColor string, path string) {
-	content, err := fs.ReadFile(fsys, path)
+	content, err := fs.ReadFile(fsys, snippetSourcePath(fsys, path, loc.filePath))
 	if err != nil {
 		fmt.Fprintf(w, "%*s %s|%s %sCould not read source file: %v%s\n", loc.numWidth, "", s.cyan, s.reset, severityColor, err, s.reset)
 		return


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

This pull request addresses error handling and path resolution issues in diagnostic snippet processing across two key areas:

**Web Store (File Tree)**
- Enhanced error handling in the `loadSharedFiles` function by wrapping shared tree grafting operations in try/catch logic
- Changed behavior to gracefully handle failures by returning a `loaded: false` state instead of throwing exceptions, improving application stability

**Diagnostics Printer (Go)**
- Introduced a `snippetSourcePath` utility function to properly resolve the actual file paths for reading diagnostic snippets
- Updated the snippet reading logic to use intelligent path resolution that accounts for whether the path is a file, directory, or project reference
- This ensures diagnostic snippets are read from the correct location based on the provided context

Together, these changes improve the reliability of diagnostic snippet retrieval by implementing proper error handling and fixing the source path resolution logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->