### PR TITLE
Add script to manage submodule remote and reset

### DIFF
--- a/scripts/change-gbal.sh
+++ b/scripts/change-gbal.sh
@@ -16,6 +16,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Updates the `packages/wasm/ballerina-lang-go` submodule source.
+# - Switch mode: points the submodule to a given remote + branch.
+# - Reset mode: restores the submodule to the repository-pinned commit.
+
 set -e
 
 SUBMODULE_DIR="packages/wasm/ballerina-lang-go"

--- a/scripts/change-gbal.sh
+++ b/scripts/change-gbal.sh
@@ -24,11 +24,12 @@ usage() {
     echo "Usage:"
     echo "  $0 <remote-url> <branch>"
     echo "  $0 --reset"
+    exit 1
 }
 
 reset() {
     echo "Resetting submodule..."
-    git submodule update --init --force
+    git submodule update --init --force "$SUBMODULE_DIR"
     echo "Submodule reset complete."
 }
 

--- a/scripts/change-gbal.sh
+++ b/scripts/change-gbal.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+SUBMODULE_DIR="packages/wasm/ballerina-lang-go"
+
+usage() {
+    echo "Usage:"
+    echo "  $0 <remote-url> <branch>"
+    echo "  $0 --reset"
+}
+
+reset() {
+    echo "Resetting submodule..."
+    git submodule update --init --force
+    echo "Submodule reset complete."
+}
+
+switch() {
+    local remote_url=$1
+    local branch=$2
+
+    echo "Pointing submodule to $remote_url @ $branch..."
+
+    pushd "$SUBMODULE_DIR" > /dev/null 
+
+    git remote add temp "$remote_url" 2>/dev/null || git remote set-url temp "$remote_url"
+    git fetch temp "$branch"
+    git checkout "temp/$branch"
+
+    popd > /dev/null
+
+    echo "Submodule now pointing to $remote_url @ $branch."
+}
+
+case "$1" in
+  --reset)
+    reset
+    ;;
+  "")
+    usage
+    ;;
+  *)
+    [ -z "$2" ] && usage
+    switch "$1" "$2"
+    ;;
+esac


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This pull request adds a new Bash utility script, scripts/change-gbal.sh, to simplify managing the Git submodule at packages/wasm/ballerina-lang-go.

Key changes:
- New script: scripts/change-gbal.sh
  - Switch remote and branch: adds or updates a temporary remote, fetches the specified branch from that remote, and checks out the fetched branch inside the submodule.
  - Reset option: --reset reinitializes the submodule using git submodule update --init --force to restore the repository-pinned commit.
  - Usage/help messaging, informative echo output, and set -e for fail-fast behavior.
  - Includes header/license and inline comments documenting purpose and modes.

Intended outcome:
- Make it easier for developers to repoint or restore the submodule during development and testing workflows, improving developer productivity when switching or resetting submodule sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->