### PR TITLE
Disable share option for non-example files

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -54,6 +54,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { getExamplesSubtree, getSharedSubtree } from "@/lib/file-tree-utils";
 import {
 	basename,
+	isShareablePath,
 	dirname,
 	isExamplesPath,
 	isActiveOrAncestor,
@@ -146,10 +147,12 @@ function FileTreeFileNode({ node, path }: FileTreeNodeProps) {
 								<span>Rename</span>
 							</DropdownMenuItem>
 						)}
-						<DropdownMenuItem onClick={() => void copyShareLink(path)}>
-							<HugeiconsIcon icon={Share08Icon} strokeWidth={1.5} />
-							<span>Share</span>
-						</DropdownMenuItem>
+						{isShareablePath(path) && (
+							<DropdownMenuItem onClick={() => void copyShareLink(path)}>
+								<HugeiconsIcon icon={Share08Icon} strokeWidth={1.5} />
+								<span>Share</span>
+							</DropdownMenuItem>
+						)}
 						{isSharedFile && (
 							<DropdownMenuItem
 								onClick={() => {
@@ -297,10 +300,12 @@ function FileTreeDirNode({
 									<span>Rename</span>
 								</DropdownMenuItem>
 							)}
-							<DropdownMenuItem onClick={() => void copyShareLink(path)}>
-								<HugeiconsIcon icon={Share08Icon} strokeWidth={1.5} />
-								<span>Share</span>
-							</DropdownMenuItem>
+							{isShareablePath(path) && (
+								<DropdownMenuItem onClick={() => void copyShareLink(path)}>
+									<HugeiconsIcon icon={Share08Icon} strokeWidth={1.5} />
+									<span>Share</span>
+								</DropdownMenuItem>
+							)}
 							{isSharedDir && (
 								<DropdownMenuItem
 									onClick={() => {

--- a/apps/web/src/lib/fs/core/path-utils.ts
+++ b/apps/web/src/lib/fs/core/path-utils.ts
@@ -67,6 +67,10 @@ export function isExamplesPath(path: string): boolean {
 	return isUnder(path, EXAMPLES_ROOT);
 }
 
+export function isShareablePath(path: string): boolean {
+	return isExamplesPath(path) || isSharedPath(path);
+}
+
 export function sharedToLocalDestination(sharedPath: string): string | null {
 	const rel = getRelativePath(SHARED_ROOT, sharedPath);
 	if (rel === null) return null;


### PR DESCRIPTION
## Purpose

$subject


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request restricts the share functionality in the application's file management interface to a specific set of allowed paths.

### Changes Made

**New Utility Function**
- Added `isShareablePath()` utility function to `apps/web/src/lib/fs/core/path-utils.ts` that determines whether a given path can be shared by checking if it belongs to either the examples or shared root directories.

**UI Updates**
- Updated `apps/web/src/components/app-sidebar.tsx` to conditionally render the "Share" option in the dropdown menu only for files and directories that pass the `isShareablePath()` check.
- Other file actions (Rename, Fork, Delete) remain available as before.

### Impact

The share option is now restricted to files and directories within designated example and shared paths, preventing users from sharing arbitrary user-created files through the share functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->