### PR TITLE
Fix share option for directories

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -71,9 +71,14 @@ type FileTreeNodeProps = {
 	node: FileNode;
 	path: string;
 	defaultOpen?: boolean;
+	shareable?: boolean;
 };
 
-function FileTreeFileNode({ node, path }: FileTreeNodeProps) {
+function FileTreeFileNode({
+	node,
+	path,
+	shareable = false,
+}: FileTreeNodeProps) {
 	const { copyShareLink } = useCopyShareLink();
 
 	const isMobile = useIsMobile();
@@ -147,7 +152,7 @@ function FileTreeFileNode({ node, path }: FileTreeNodeProps) {
 								<span>Rename</span>
 							</DropdownMenuItem>
 						)}
-						{isShareablePath(path) && (
+						{shareable && (
 							<DropdownMenuItem onClick={() => void copyShareLink(path)}>
 								<HugeiconsIcon icon={Share08Icon} strokeWidth={1.5} />
 								<span>Share</span>
@@ -200,12 +205,14 @@ type FileTreeDirNodeProps = {
 	node: Extract<FileNode, { kind: "dir" }>;
 	path: string;
 	defaultOpen?: boolean;
+	shareable?: boolean;
 };
 
 function FileTreeDirNode({
 	node,
 	path,
 	defaultOpen = false,
+	shareable = false,
 }: FileTreeDirNodeProps) {
 	const { copyShareLink } = useCopyShareLink();
 
@@ -300,7 +307,7 @@ function FileTreeDirNode({
 									<span>Rename</span>
 								</DropdownMenuItem>
 							)}
-							{isShareablePath(path) && (
+							{shareable && (
 								<DropdownMenuItem onClick={() => void copyShareLink(path)}>
 									<HugeiconsIcon icon={Share08Icon} strokeWidth={1.5} />
 									<span>Share</span>
@@ -371,8 +378,22 @@ function FileTreeDirNode({
 }
 
 function FileTreeNode({ node, path, defaultOpen }: FileTreeNodeProps) {
-	if (node.kind === "file") return <FileTreeFileNode node={node} path={path} />;
-	return <FileTreeDirNode node={node} path={path} defaultOpen={defaultOpen} />;
+	if (node.kind === "file")
+		return (
+			<FileTreeFileNode
+				node={node}
+				path={path}
+				shareable={isShareablePath(path)}
+			/>
+		);
+	return (
+		<FileTreeDirNode
+			node={node}
+			path={path}
+			defaultOpen={defaultOpen}
+			shareable={true}
+		/>
+	);
 }
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {

--- a/apps/web/src/lib/fs/core/abstract-fs.ts
+++ b/apps/web/src/lib/fs/core/abstract-fs.ts
@@ -48,7 +48,7 @@ export class AbstractFS implements FS {
 
 	readDir(path: string): { name: string; isDir: boolean }[] | null {
 		const node = this._getNode(path, false);
-		if (!node || !node.isDir || !node.children) return null;
+		if (!node?.isDir || !node.children) return null;
 		return Object.entries(node.children).map(([name, child]) => ({
 			name,
 			isDir: child.isDir,

--- a/apps/web/src/stores/file-tree-store.ts
+++ b/apps/web/src/stores/file-tree-store.ts
@@ -130,7 +130,7 @@ export const useFileTreeStore = create<FileTreeState & FileTreeActions>()(
 
 			saveFile() {
 				const { activeFile } = get();
-				if (!activeFile || !activeFile.dirty) return false;
+				if (!activeFile?.dirty) return false;
 				const result = _fs().writeFile(activeFile.path, activeFile.content);
 				if (!result) return false;
 				set((s) => {
@@ -307,7 +307,7 @@ export const useFileTreeStore = create<FileTreeState & FileTreeActions>()(
 						s.localTree = _fs().localTree();
 					});
 					return { loaded: true, openPath };
-				} catch (e) {
+				} catch {
 					return { loaded: false, openPath: null };
 				}
 			},


### PR DESCRIPTION
## Purpose

$subject


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes the share functionality for directories by introducing a `shareable` prop to the file tree components. Previously, the share option was only conditionally rendered based on specific path logic; now it can be explicitly enabled for directory nodes, allowing users to share directories alongside files.

## Changes

**File Tree Component Updates** (`app-sidebar.tsx`)
- Added a `shareable` prop to file and directory node components to control whether the share option is displayed
- Enabled directory sharing by passing `shareable={true}` for all directory nodes
- Preserved existing share behavior for file nodes based on path shareability rules

**Code Quality Improvements**
- Enhanced null safety in the file system abstraction layer using optional chaining for directory property checks
- Simplified error handling in the file tree store by removing unused error variable bindings
- Improved consistency of optional property checks across the codebase

These changes maintain backward compatibility while extending the share functionality to directories and improving overall code stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->