### PR TITLE
Refactor remove unreachable nolocalfiles condition

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -125,7 +125,7 @@ function FileTreeFileNode({
 					{node.name}
 				</SidebarMenuButton>
 				<DropdownMenu>
-					<DropdownMenuTrigger
+					<DropdownMenuTrigger  
 						render={
 							<SidebarMenuAction className="peer-data-[active=true]/menu-button:opacity-100 group-hover/row:opacity-100 group-focus-within/row:opacity-100 aria-expanded:opacity-100 md:opacity-0" />
 						}
@@ -415,7 +415,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 	const activeFilePath = useActiveFilePath();
 	const { setFileOperationDialog } = useFileTreeActions();
 
-	const noLocalFiles = localTree.length === 0;
 
 	return (
 		<Sidebar {...props}>
@@ -475,17 +474,14 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 									defaultOpen={isActiveOrAncestor(path, activeFilePath)}
 								/>
 							))}
-							{localTree.map((node, index) => {
+							{localTree.map((node) => {
 								const path = `${LOCAL_ROOT}/${node.name}`;
 								return (
 									<FileTreeNode
 										key={`local:${node.name}`}
 										node={node}
 										path={path}
-										defaultOpen={
-											isActiveOrAncestor(path, activeFilePath) ||
-											(noLocalFiles && index === 0)
-										}
+										defaultOpen={isActiveOrAncestor(path, activeFilePath)}
 									/>
 								);
 							})}

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -125,7 +125,7 @@ function FileTreeFileNode({
 					{node.name}
 				</SidebarMenuButton>
 				<DropdownMenu>
-					<DropdownMenuTrigger  
+					<DropdownMenuTrigger
 						render={
 							<SidebarMenuAction className="peer-data-[active=true]/menu-button:opacity-100 group-hover/row:opacity-100 group-focus-within/row:opacity-100 aria-expanded:opacity-100 md:opacity-0" />
 						}
@@ -414,7 +414,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 
 	const activeFilePath = useActiveFilePath();
 	const { setFileOperationDialog } = useFileTreeActions();
-
 
 	return (
 		<Sidebar {...props}>


### PR DESCRIPTION
## Purpose
Removes an unreachable condition in the app sidebar component related to the `defaultOpen` logic.

## Summary
This pull request simplifies the `defaultOpen` logic in the app sidebar component by removing a condition that can never be true.

## Key Changes

**Code Cleanup:**
- Removed `(noLocalFiles && index === 0)` from the `defaultOpen` condition inside `localTree.map()` in `app-sidebar.tsx`
- Removed unused `index` parameter from the `.map()` callback
- Removed unused `noLocalFiles` variable

**Logic Simplification:**
- `noLocalFiles` implies `localTree.length === 0`, so the `.map()` callback never executes
- Therefore, the condition was unreachable and had no effect on behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request refactors the app sidebar to remove unreachable conditional logic and simplify the local file tree rendering.

### Changes Made

- apps/web/src/components/app-sidebar.tsx
  - Removed the computed flag `noLocalFiles` (derived from `localTree.length === 0`).
  - Removed the unreachable `(noLocalFiles && index === 0)` fallback from the `localTree.map()` rendering and updated `defaultOpen` to rely solely on whether the node path is active or an ancestor of the active file.
  - Removed the unused `index` parameter from the `localTree.map()` callback.

### Impact

Improves code clarity and maintainability by eliminating dead code that could never execute; behavior remains unchanged because the removed condition was unreachable. Lines changed: +2/-7
<!-- end of auto-generated comment: release notes by coderabbit.ai -->