### PR TITLE
Display Ballerina and Playground versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,5 @@ jobs:
         run: bun run lint
 
       - name: Build web app
-        run: bun run build --filter=@playground/web
+        run: bun run build
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,9 @@ jobs:
         run: bun install
 
       - name: Build web app 
-        run: bun run build --filter=@playground/web
+        run: bun run build
+        env:
+          COMMIT_SHA: ${{ github.sha }}
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -23,5 +23,6 @@ dist-ssr
 *.sln
 *.sw?
 
-# Generated WebAssembly binary
 public/ballerina.wasm
+public/ballerina-meta.json
+

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
 		"dev": "vite",
 		"build": "tsc -b && vite build",
 		"preview": "vite preview",
-		"copy:wasm": "cp ../../packages/wasm/dist/ballerina.wasm public/ballerina.wasm",
+		"copy:wasm": "cp ../../packages/wasm/dist/ballerina.wasm public/ballerina.wasm && cp ../../packages/wasm/dist/ballerina-meta.json public/ballerina-meta.json",
 		"clean": "git clean -xdf .turbo dist node_modules"
 	},
 	"dependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,17 +12,17 @@
 	"dependencies": {
 		"@base-ui/react": "^1.3.0",
 		"@fontsource-variable/jetbrains-mono": "^5.2.8",
-		"@hugeicons/core-free-icons": "^4.0.0",
+		"@hugeicons/core-free-icons": "^4.1.1",
 		"@hugeicons/react": "^1.1.6",
 		"@tailwindcss/vite": "^4.2.1",
-		"@tanstack/react-router": "^1.168.1",
+		"@tanstack/react-router": "^1.168.10",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"immer": "^11.1.4",
 		"react": "^19.2.4",
 		"react-dom": "^19.2.4",
 		"react-hotkeys-hook": "^5.2.4",
-		"shadcn": "^4.0.7",
+		"shadcn": "^4.1.2",
 		"shiki": "^4.0.2",
 		"sonner": "^2.0.7",
 		"tailwind-merge": "^3.5.0",
@@ -31,13 +31,13 @@
 		"zustand": "^5.0.11"
 	},
 	"devDependencies": {
-		"@tanstack/router-plugin": "^1.167.1",
-		"@types/node": "^25.5.0",
+		"@tanstack/router-plugin": "^1.167.12",
+		"@types/node": "^25.5.2",
 		"@types/react": "^19.2.14",
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^6.0.1",
 		"globals": "^17.4.0",
-		"typescript": "~5.9.3",
-		"vite": "^8.0.0"
+		"typescript": "~6.0.2",
+		"vite": "^8.0.4"
 	}
 }

--- a/apps/web/src/components/editor.tsx
+++ b/apps/web/src/components/editor.tsx
@@ -20,6 +20,7 @@ import { Progress } from "@/components/ui/progress";
 
 import { AppSidebar } from "@/components/app-sidebar";
 import { CodeEditor } from "@/components/code-editor";
+import { VersionCard } from "@/components/version-card";
 import { ANSI } from "@/components/ansi";
 
 import {
@@ -179,7 +180,8 @@ function EditorHeader() {
 				<SidebarTrigger className="-ml-1" />
 				<h1 className="text-sm font-medium">Ballerina Playground</h1>
 			</div>
-			<div>
+			<div className="flex items-center gap-4">
+				<VersionCard />
 				<a
 					className="flex items-center gap-2 text-xs text-muted-foreground hover:text-secondary-foreground"
 					href="https://github.com/ballerina-platform/playground"

--- a/apps/web/src/components/ui/hover-card.tsx
+++ b/apps/web/src/components/ui/hover-card.tsx
@@ -1,0 +1,49 @@
+import { PreviewCard as PreviewCardPrimitive } from "@base-ui/react/preview-card";
+
+import { cn } from "@/lib/utils";
+
+function HoverCard({ ...props }: PreviewCardPrimitive.Root.Props) {
+	return <PreviewCardPrimitive.Root data-slot="hover-card" {...props} />;
+}
+
+function HoverCardTrigger({ ...props }: PreviewCardPrimitive.Trigger.Props) {
+	return (
+		<PreviewCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
+	);
+}
+
+function HoverCardContent({
+	className,
+	side = "bottom",
+	sideOffset = 4,
+	align = "center",
+	alignOffset = 4,
+	...props
+}: PreviewCardPrimitive.Popup.Props &
+	Pick<
+		PreviewCardPrimitive.Positioner.Props,
+		"align" | "alignOffset" | "side" | "sideOffset"
+	>) {
+	return (
+		<PreviewCardPrimitive.Portal data-slot="hover-card-portal">
+			<PreviewCardPrimitive.Positioner
+				align={align}
+				alignOffset={alignOffset}
+				side={side}
+				sideOffset={sideOffset}
+				className="isolate z-50"
+			>
+				<PreviewCardPrimitive.Popup
+					data-slot="hover-card-content"
+					className={cn(
+						"z-50 w-64 origin-(--transform-origin) rounded-none bg-popover p-2.5 text-xs/relaxed text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+						className,
+					)}
+					{...props}
+				/>
+			</PreviewCardPrimitive.Positioner>
+		</PreviewCardPrimitive.Portal>
+	);
+}
+
+export { HoverCard, HoverCardTrigger, HoverCardContent };

--- a/apps/web/src/components/version-card.tsx
+++ b/apps/web/src/components/version-card.tsx
@@ -1,0 +1,75 @@
+import {
+	HoverCard,
+	HoverCardContent,
+	HoverCardTrigger,
+} from "@/components/ui/hover-card";
+
+interface VersionRowProps {
+	label: string;
+	value: string;
+	href?: string;
+}
+
+function VersionRow({ label, value, href }: VersionRowProps) {
+	const inner = <span>{value}</span>;
+	return (
+		<div className="flex items-center justify-between gap-8 text-xs text-muted-foreground">
+			<span>{label}</span>
+			{href ? (
+				<a
+					className="hover:text-secondary-foreground"
+					href={href}
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					{inner}
+				</a>
+			) : (
+				inner
+			)}
+		</div>
+	);
+}
+
+function getGitHubUrl(
+	repo: string,
+	version: string,
+	sentinel: string,
+): string | undefined {
+	if (version === sentinel) return undefined;
+	const isTag = /^v\d+\.\d+\.\d+/.test(version);
+	const suffix = isTag ? `releases/tag/${version}` : `commit/${version}`;
+	return `https://github.com/ballerina-platform/${repo}/${suffix}`;
+}
+
+export function VersionCard() {
+	const rows: VersionRowProps[] = [
+		{
+			label: "Ballerina Interpreter",
+			value: __BALLERINA_VERSION__,
+			href: getGitHubUrl("ballerina-lang-go", __BALLERINA_VERSION__, "unknown"),
+		},
+		{
+			label: "Playground",
+			value: __COMMIT_SHA__ !== "dev" ? __COMMIT_SHA__.slice(0, 7) : "dev",
+			href: getGitHubUrl("playground", __COMMIT_SHA__, "dev"),
+		},
+	];
+
+	return (
+		<HoverCard>
+			<HoverCardTrigger className="text-xs text-muted-foreground select-none">
+				{__BALLERINA_VERSION__}
+			</HoverCardTrigger>
+			<HoverCardContent
+				className="flex w-full max-w-105 flex-col gap-2 p-3 text-muted-foreground select-none"
+				side="bottom"
+				align="end"
+			>
+				{rows.map((row) => (
+					<VersionRow key={row.label} {...row} />
+				))}
+			</HoverCardContent>
+		</HoverCard>
+	);
+}

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,2 @@
+declare const __BALLERINA_VERSION__: string;
+declare const __COMMIT_SHA__: string;

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -21,7 +21,7 @@
 		"erasableSyntaxOnly": false,
 		"noFallthroughCasesInSwitch": true,
 		"noUncheckedSideEffectImports": true,
-		"baseUrl": ".",
+		"rootDir": ".",
 		"paths": {
 			"@/*": ["./src/*"]
 		}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -5,7 +5,7 @@
 		{ "path": "./tsconfig.node.json" }
 	],
 	"compilerOptions": {
-		"baseUrl": ".",
+		"rootDir": ".",
 		"paths": {
 			"@/*": ["./src/*"]
 		}

--- a/apps/web/turbo.json
+++ b/apps/web/turbo.json
@@ -14,6 +14,12 @@
 			"dependsOn": ["copy:wasm"],
 			"cache": false,
 			"persistent": true
+		},
+		"preview": {
+			"env": ["COMMIT_SHA"],
+			"dependsOn": ["build"],
+			"cache": false,
+			"persistent": true
 		}
 	}
 }

--- a/apps/web/turbo.json
+++ b/apps/web/turbo.json
@@ -3,14 +3,19 @@
 	"tasks": {
 		"copy:wasm": {
 			"dependsOn": ["@playground/wasm#build"],
-			"inputs": ["../../packages/wasm/dist/ballerina.wasm"],
-			"outputs": ["public/ballerina.wasm"]
+			"inputs": [
+				"../../packages/wasm/dist/ballerina.wasm",
+				"../../packages/wasm/dist/ballerina-meta.json"
+			],
+			"outputs": ["public/ballerina.wasm", "public/ballerina-meta.json"]
 		},
 		"build": {
+			"env": ["COMMIT_SHA"],
 			"dependsOn": ["^build", "copy:wasm"],
 			"outputs": ["dist/**"]
 		},
 		"dev": {
+			"env": ["COMMIT_SHA"],
 			"dependsOn": ["copy:wasm"],
 			"cache": false,
 			"persistent": true

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,4 +1,4 @@
-import fs from "node:fs/promises";
+import fs from "node:fs";
 import path from "node:path";
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
@@ -6,6 +6,11 @@ import { defineConfig } from "vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 
 import type { Plugin } from "vite";
+
+const metaPath = path.resolve(__dirname, "public/ballerina-meta.json");
+const meta = fs.existsSync(metaPath)
+	? JSON.parse(fs.readFileSync(metaPath, "utf-8"))
+	: { version: "unknown" };
 
 function githubPagesSpa(): Plugin {
 	let outDir: string;
@@ -17,24 +22,32 @@ function githubPagesSpa(): Plugin {
 		},
 		async closeBundle() {
 			const indexHtml = path.join(outDir, "index.html");
-			await fs.copyFile(indexHtml, path.join(outDir, "404.html"));
+			await fs.promises.copyFile(indexHtml, path.join(outDir, "404.html"));
 		},
 	};
 }
 
-export default defineConfig({
-	plugins: [
-		tanstackRouter({
-			target: "react",
-			autoCodeSplitting: true,
-		}),
-		tailwindcss(),
-		react(),
-		githubPagesSpa(),
-	],
-	resolve: {
-		alias: {
-			"@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+	return {
+		define: {
+			__BALLERINA_VERSION__: JSON.stringify(meta.version),
+			__COMMIT_SHA__: JSON.stringify(
+				(mode === "production" && process.env.COMMIT_SHA) || "dev",
+			),
 		},
-	},
+		plugins: [
+			tanstackRouter({
+				target: "react",
+				autoCodeSplitting: true,
+			}),
+			tailwindcss(),
+			react(),
+			githubPagesSpa(),
+		],
+		resolve: {
+			alias: {
+				"@": path.resolve(__dirname, "./src"),
+			},
+		},
+	};
 });

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "@playground/monorepo",
       "devDependencies": {
         "@biomejs/biome": "^2.4.10",
-        "turbo": "^2.9.0",
+        "turbo": "^2.9.4",
       },
     },
     "apps/web": {
@@ -14,17 +14,17 @@
       "dependencies": {
         "@base-ui/react": "^1.3.0",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
-        "@hugeicons/core-free-icons": "^4.0.0",
+        "@hugeicons/core-free-icons": "^4.1.1",
         "@hugeicons/react": "^1.1.6",
         "@tailwindcss/vite": "^4.2.1",
-        "@tanstack/react-router": "^1.168.1",
+        "@tanstack/react-router": "^1.168.10",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "immer": "^11.1.4",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-hotkeys-hook": "^5.2.4",
-        "shadcn": "^4.0.7",
+        "shadcn": "^4.1.2",
         "shiki": "^4.0.2",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
@@ -33,14 +33,14 @@
         "zustand": "^5.0.11",
       },
       "devDependencies": {
-        "@tanstack/router-plugin": "^1.167.1",
-        "@types/node": "^25.5.0",
+        "@tanstack/router-plugin": "^1.167.12",
+        "@types/node": "^25.5.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "globals": "^17.4.0",
-        "typescript": "~5.9.3",
-        "vite": "^8.0.0",
+        "typescript": "~6.0.2",
+        "vite": "^8.0.4",
       },
     },
     "packages/wasm": {
@@ -202,7 +202,7 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
-    "@hugeicons/core-free-icons": ["@hugeicons/core-free-icons@4.0.0", "", {}, "sha512-bzfbKumv3ke3ajbe2MyXi9i0I/cdsZ6n/mO9EfIPNSL++pHLqs7nSGRIVUtjF4xrrEyVkfhxssv4Jek8DPA6gA=="],
+    "@hugeicons/core-free-icons": ["@hugeicons/core-free-icons@4.1.1", "", {}, "sha512-teqIBvPHl90ygIwKyJwTxOH8aNp1X1PjDTcMvLkEwdPxPD+8mssrZ5kXKIAJJFYPsz69a8LYQY0UPid4PAdavg=="],
 
     "@hugeicons/react": ["@hugeicons/react@1.1.6", "", { "peerDependencies": { "react": ">=16.0.0" } }, "sha512-c2LhXJMAW5wN1pC/smBXG0YPqUON6ceR/ZdXHCjEI9KvB+hjtqYjmzIxok5hAQOeXGz0WtORgCQMzqewFKAZwg=="],
 
@@ -340,15 +340,15 @@
 
     "@tanstack/history": ["@tanstack/history@1.161.6", "", {}, "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg=="],
 
-    "@tanstack/react-router": ["@tanstack/react-router@1.168.7", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.168.6", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-fW/HvQja4PQeu9lsoyh+pXpZ0UXezbpQkkJvCuH6tHAaW3jvPkjh14lfadrNNiY+pXT7WiMTB3afGhTCC78PDQ=="],
+    "@tanstack/react-router": ["@tanstack/react-router@1.168.10", "", { "dependencies": { "@tanstack/history": "1.161.6", "@tanstack/react-store": "^0.9.3", "@tanstack/router-core": "1.168.9", "isbot": "^5.1.22" }, "peerDependencies": { "react": ">=18.0.0 || >=19.0.0", "react-dom": ">=18.0.0 || >=19.0.0" } }, "sha512-/RmDlOwDkCug609KdPB3U+U1zmrtadJpvsmRg2zEn8TRCKRNri7dYZIjQZbNg8PgUiRL4T6njrZBV1ChzblNaA=="],
 
     "@tanstack/react-store": ["@tanstack/react-store@0.9.3", "", { "dependencies": { "@tanstack/store": "0.9.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg=="],
 
-    "@tanstack/router-core": ["@tanstack/router-core@1.168.6", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^2.0.0", "seroval": "^1.4.2", "seroval-plugins": "^1.4.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-okCno3pImpLFQMJ/4zqEIGjIV5yhxLGj0JByrzQDQehORN1y1q6lJUezT0KPK5qCQiKUApeWaboLPjgBVx1kaQ=="],
+    "@tanstack/router-core": ["@tanstack/router-core@1.168.9", "", { "dependencies": { "@tanstack/history": "1.161.6", "cookie-es": "^2.0.0", "seroval": "^1.4.2", "seroval-plugins": "^1.4.2" }, "bin": { "intent": "bin/intent.js" } }, "sha512-18oeEwEDyXOIuO1VBP9ACaK7tYHZUjynGDCoUh/5c/BNhia9vCJCp9O0LfhZXOorDc/PmLSgvmweFhVmIxF10g=="],
 
-    "@tanstack/router-generator": ["@tanstack/router-generator@1.166.21", "", { "dependencies": { "@tanstack/router-core": "1.168.6", "@tanstack/router-utils": "1.161.6", "@tanstack/virtual-file-routes": "1.161.7", "prettier": "^3.5.0", "recast": "^0.23.11", "source-map": "^0.7.4", "tsx": "^4.19.2", "zod": "^3.24.2" } }, "sha512-pJWsP6HaGrkIkfkcg6vzKyCBMbf1vV1BrQH+bFAVzXj3T/afmix3IPV2hiAj4zzjMxuddJD1on0Hn5+WDYA7zQ=="],
+    "@tanstack/router-generator": ["@tanstack/router-generator@1.166.24", "", { "dependencies": { "@tanstack/router-core": "1.168.9", "@tanstack/router-utils": "1.161.6", "@tanstack/virtual-file-routes": "1.161.7", "prettier": "^3.5.0", "recast": "^0.23.11", "source-map": "^0.7.4", "tsx": "^4.19.2", "zod": "^3.24.2" } }, "sha512-vdaGKwuH+r+DPe6R1mjk+TDDmDH6NTG7QqwxHqGEvOH4aGf9sPjhmRKNJZqQr8cPIbfp6u5lXyZ1TeDcSNMVEA=="],
 
-    "@tanstack/router-plugin": ["@tanstack/router-plugin@1.167.8", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.168.6", "@tanstack/router-generator": "1.166.21", "@tanstack/router-utils": "1.161.6", "@tanstack/virtual-file-routes": "1.161.7", "chokidar": "^3.6.0", "unplugin": "^2.1.2", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2", "@tanstack/react-router": "^1.168.7", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0", "vite-plugin-solid": "^2.11.10", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"], "bin": { "intent": "bin/intent.js" } }, "sha512-/X4ACYsSX4bRmomj5X2TBU75cHuIVI99Fsax6DWnP6hPb4PaSjPUHVBfHhk2NemJzEOZu1L31UQ9QDlbHU4ZTQ=="],
+    "@tanstack/router-plugin": ["@tanstack/router-plugin@1.167.12", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/template": "^7.27.2", "@babel/traverse": "^7.28.5", "@babel/types": "^7.28.5", "@tanstack/router-core": "1.168.9", "@tanstack/router-generator": "1.166.24", "@tanstack/router-utils": "1.161.6", "@tanstack/virtual-file-routes": "1.161.7", "chokidar": "^3.6.0", "unplugin": "^2.1.2", "zod": "^3.24.2" }, "peerDependencies": { "@rsbuild/core": ">=1.0.2", "@tanstack/react-router": "^1.168.10", "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0", "vite-plugin-solid": "^2.11.10", "webpack": ">=5.92.0" }, "optionalPeers": ["@rsbuild/core", "@tanstack/react-router", "vite", "vite-plugin-solid", "webpack"], "bin": { "intent": "bin/intent.js" } }, "sha512-StEHcctCuFI5taSjO+lhR/yQ+EK63BdyYa+ne6FoNQPB3MMrOUrz2ZVnbqILRLkh2b+p2EfBKt65sgAKdKygPQ=="],
 
     "@tanstack/router-utils": ["@tanstack/router-utils@1.161.6", "", { "dependencies": { "@babel/core": "^7.28.5", "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-nRcYw+w2OEgK6VfjirYvGyPLOK+tZQz1jkYcmH5AjMamQ9PycnlxZF2aEZtPpNoUsaceX2bHptn6Ub5hGXqNvw=="],
 
@@ -358,17 +358,17 @@
 
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 
-    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-owaWYafOebw2en9INuP321/fSN82pIQl38VLgIDd6YJ7+jUasEkORQEkWUC8aAqsIsukLhbGdPnklzUqBwBijQ=="],
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZSlPqJ5Vqg/wgVw8P3AOVCIosnbBilOxLq7TMz3MN/9U46DUYfdG2jtfevNDufyxyrg98pcPs/GBgDRaaids6g=="],
 
-    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-1Jj+CXYexJraJ/vvNg5fN9cyVKx/KJyDcWVHvqZWc3aMCC/M4+HxUtnrMu1MEttv5gA4vKOGwa2FCJ9VmfSUGg=="],
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9cjTWe4OiNlFMSRggPNh+TJlRs7MS5FWrHc96MOzft5vESWjjpvaadYPv5ykDW7b45mVHOF2U/W+48LoX9USWw=="],
 
-    "@turbo/linux-64": ["@turbo/linux-64@2.9.0", "", { "os": "linux", "cpu": "x64" }, "sha512-OcCTATltui6jKitb+PaYwiIkLi3bjBP9+9e7gyh0jbivXKoeIFQniMMXbXScQY28zidHw300Ym5itxBMsT/tGw=="],
+    "@turbo/linux-64": ["@turbo/linux-64@2.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-Cl1GjxqBXQ+r9KKowmXG+lhD1gclLp48/SE7NxL//66iaMytRw0uiphWGOkccD92iPiRjHLRUaA9lOTtgr5OCA=="],
 
-    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-+NaycIHwYmwt5WLa6V5OZGgtvPwUTwenA7cYLHo+QBsGW7uGROPvOpFU0WED2C5KcGvlu4GP9ks3Ih6Cg5oZew=="],
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-j2hPAKVmGNN2EsKigEWD+43y9m7zaPhNAs6ptsyfq0u7evHHBAXAwOfv86OEMg/gvC+pwGip0i1CIm1bR1vYug=="],
 
-    "@turbo/windows-64": ["@turbo/windows-64@2.9.0", "", { "os": "win32", "cpu": "x64" }, "sha512-HCFf7WXdGWzCQw76/34l/BdYC9tzOihYAQX6ks34WY6MnhpPPAO9YbfV1c/SBcTIjpnQhoAGEBBYrQQ9h7R18w=="],
+    "@turbo/windows-64": ["@turbo/windows-64@2.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-1jWPjCe9ZRmsDTXE7uzqfySNQspnUx0g6caqvwps+k/sc+fm9hC/4zRQKlXZLbVmP3Xxp601Ju71boegHdnYGw=="],
 
-    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-/pdxvCMtom9qYplukZzacCL96Vht/datjiRYc3M1geknY+mg8+f047xLxe98PwNhX1sZyovea4RtH8bNU7JLGA=="],
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-dlko15TQVu/BFYmIY018Y3covWMRQlUgAkD+OOk+Rokcfj6VY02Vv4mCfT/Zns6B4q8jGbOd6IZhnCFYsE8Viw=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
@@ -376,7 +376,7 @@
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
-    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+    "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -932,7 +932,7 @@
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
-    "shadcn": ["shadcn@4.1.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/parser": "^7.28.0", "@babel/plugin-transform-typescript": "^7.28.0", "@babel/preset-typescript": "^7.27.1", "@dotenvx/dotenvx": "^1.48.4", "@modelcontextprotocol/sdk": "^1.26.0", "@types/validate-npm-package-name": "^4.0.2", "browserslist": "^4.26.2", "commander": "^14.0.0", "cosmiconfig": "^9.0.0", "dedent": "^1.6.0", "deepmerge": "^4.3.1", "diff": "^8.0.2", "execa": "^9.6.0", "fast-glob": "^3.3.3", "fs-extra": "^11.3.1", "fuzzysort": "^3.1.0", "https-proxy-agent": "^7.0.6", "kleur": "^4.1.5", "msw": "^2.10.4", "node-fetch": "^3.3.2", "open": "^11.0.0", "ora": "^8.2.0", "postcss": "^8.5.6", "postcss-selector-parser": "^7.1.0", "prompts": "^2.4.2", "recast": "^0.23.11", "stringify-object": "^5.0.0", "tailwind-merge": "^3.0.1", "ts-morph": "^26.0.0", "tsconfig-paths": "^4.2.0", "validate-npm-package-name": "^7.0.1", "zod": "^3.24.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "shadcn": "dist/index.js" } }, "sha512-3zETJ+0Ezj69FS6RL0HOkLKKAR5yXisXx1iISJdfLQfrUqj/VIQlanQi1Ukk+9OE+XHZVj4FQNTBSfbr2CyCYg=="],
+    "shadcn": ["shadcn@4.1.2", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/parser": "^7.28.0", "@babel/plugin-transform-typescript": "^7.28.0", "@babel/preset-typescript": "^7.27.1", "@dotenvx/dotenvx": "^1.48.4", "@modelcontextprotocol/sdk": "^1.26.0", "@types/validate-npm-package-name": "^4.0.2", "browserslist": "^4.26.2", "commander": "^14.0.0", "cosmiconfig": "^9.0.0", "dedent": "^1.6.0", "deepmerge": "^4.3.1", "diff": "^8.0.2", "execa": "^9.6.0", "fast-glob": "^3.3.3", "fs-extra": "^11.3.1", "fuzzysort": "^3.1.0", "https-proxy-agent": "^7.0.6", "kleur": "^4.1.5", "msw": "^2.10.4", "node-fetch": "^3.3.2", "open": "^11.0.0", "ora": "^8.2.0", "postcss": "^8.5.6", "postcss-selector-parser": "^7.1.0", "prompts": "^2.4.2", "recast": "^0.23.11", "stringify-object": "^5.0.0", "tailwind-merge": "^3.0.1", "ts-morph": "^26.0.0", "tsconfig-paths": "^4.2.0", "validate-npm-package-name": "^7.0.1", "zod": "^3.24.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "shadcn": "dist/index.js" } }, "sha512-qNQcCavkbYsgBj+X09tF2bTcwRd8abR880bsFkDU2kMqceMCLAm5c+cLg7kWDhfh1H9g08knpQ5ZEf6y/co16g=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -1012,7 +1012,7 @@
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
-    "turbo": ["turbo@2.9.0", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.0", "@turbo/darwin-arm64": "2.9.0", "@turbo/linux-64": "2.9.0", "@turbo/linux-arm64": "2.9.0", "@turbo/windows-64": "2.9.0", "@turbo/windows-arm64": "2.9.0" }, "bin": { "turbo": "bin/turbo" } }, "sha512-T1PcaG7rej+JLqCyIwwu9NqKiWsoTrEsiSMj4aS9xlPsXoAZw+N8yZjKRdh1WwcQPrAeB0qswgPDoHG59hF4CQ=="],
+    "turbo": ["turbo@2.9.4", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.4", "@turbo/darwin-arm64": "2.9.4", "@turbo/linux-64": "2.9.4", "@turbo/linux-arm64": "2.9.4", "@turbo/windows-64": "2.9.4", "@turbo/windows-arm64": "2.9.4" }, "bin": { "turbo": "bin/turbo" } }, "sha512-wZ/kMcZCuK5oEp7sXSSo/5fzKjP9I2EhoiarZjyCm2Ixk0WxFrC/h0gF3686eHHINoFQOOSWgB/pGfvkR8rkgQ=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
@@ -1020,7 +1020,7 @@
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -1058,7 +1058,7 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
-    "vite": ["vite@8.0.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ=="],
+    "vite": ["vite@8.0.4", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-baBr4jUVSLJ0RPyZ2nK0zS2+W8hNHbM4hEzfvllukmRPVS3xDG5ATTNtbRXrKIOE2b8/FsPWJAOnuIxcs7g3cw=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 	"scripts": {
 		"dev": "turbo run dev",
 		"build": "turbo run build",
+		"preview": "turbo run preview",
 		"format": "biome format . --write",
 		"lint": "biome check .",
 		"lint:fix": "biome check . --fix",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
 	"packageManager": "bun@1.3.10",
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.10",
-		"turbo": "^2.9.0"
+		"turbo": "^2.9.4"
 	}
 }

--- a/packages/wasm/package.json
+++ b/packages/wasm/package.json
@@ -2,7 +2,7 @@
 	"name": "@playground/wasm",
 	"private": true,
 	"scripts": {
-		"build": "GOOS=js GOARCH=wasm go build -o dist/ballerina.wasm .",
+		"build": "GOOS=js GOARCH=wasm go build -o dist/ballerina.wasm . && ./scripts/gen-meta.sh",
 		"clean": "git clean -xdf .turbo dist"
 	}
 }

--- a/packages/wasm/scripts/gen-meta.sh
+++ b/packages/wasm/scripts/gen-meta.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Generates `packages/wasm/dist/ballerina-meta.json` from the submodule state.
+# Uses an exact tag when available; otherwise records the current commit hash.
+
 cd "$(dirname "$0")/../ballerina-lang-go"
 
 TAG=$(git describe --tags --exact-match 2>/dev/null || true)

--- a/packages/wasm/scripts/gen-meta.sh
+++ b/packages/wasm/scripts/gen-meta.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")/../ballerina-lang-go"
+
+TAG=$(git describe --tags --exact-match 2>/dev/null || true)
+
+if [ -n "$TAG" ]; then
+  VERSION="$TAG"
+  TYPE="tag"
+else
+  VERSION=$(git rev-parse --short HEAD)
+  TYPE="commit"
+fi
+
+mkdir -p ../dist
+
+cat > ../dist/ballerina-meta.json << EOF
+{
+  "version": "$VERSION",
+  "type": "$TYPE",
+  "commit": "$(git rev-parse HEAD)"
+}
+EOF

--- a/packages/wasm/turbo.json
+++ b/packages/wasm/turbo.json
@@ -3,7 +3,12 @@
 	"tasks": {
 		"build": {
 			"env": ["LocalAppData"],
-			"inputs": ["**/*.go", "go.mod", "go.sum"],
+			"inputs": [
+				"**/*.go",
+				"go.mod",
+				"go.sum",
+				"../../.git/modules/packages/wasm/ballerina-lang-go/HEAD"
+			],
 			"outputs": ["dist/**"]
 		}
 	}


### PR DESCRIPTION
## Purpose
Resolves #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Implements display of Ballerina and Playground version information in the web UI and adds a build-time metadata pipeline to produce and expose those versions. Resolves issue #28.

## Changes Overview

- Version metadata pipeline
  - New script packages/wasm/scripts/gen-meta.sh generates ballerina-meta.json (version, type, commit) from the wasm submodule Git state.
  - WASM package build updated to run the metadata generator and produce dist/ballerina-meta.json.
  - Build tasks and copy scripts updated to include ballerina-meta.json so the web app receives the artifact.
  - Turbo and CI/deploy workflows updated to surface COMMIT_SHA to the web build and track the new metadata artifact.

- Frontend version display
  - Added VersionCard component (apps/web/src/components/version-card.tsx) that shows the Ballerina interpreter version and Playground commit/version in a hover card and links to appropriate GitHub release/commit pages when available.
  - Integrated VersionCard into the editor header (apps/web/src/components/editor.tsx).
  - Added a reusable HoverCard UI wrapper (apps/web/src/components/ui/hover-card.tsx) used by VersionCard.

- Build and runtime integration
  - Vite config updated to read public/ballerina-meta.json at build time and inject compile-time globals __BALLERINA_VERSION__ and __COMMIT_SHA__; __COMMIT_SHA__ is set to "dev" for non-production modes.
  - Type declarations added for the injected globals (apps/web/src/vite-env.d.ts).
  - Added a preview task and related scripts to support previewing production-like builds (turbo and root package.json).

- Supporting changes
  - Updated copy and ignore rules (.gitignore, apps/web/.gitignore) to account for the new metadata file.
  - Minor TypeScript config adjustments and dependency bumps in apps/web/package.json.
  - Small workflow and task refinements to ensure metadata and commit SHA propagate through build and deploy steps.

## Intent / Outcome

Enable the Playground UI to display the Ballerina interpreter version and the Playground build identifier to users by producing build-time metadata and surfacing it in a compact, consistent UI element. This improves transparency about the runtime and build provenance and supports testing/preview workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->