### PR TITLE
Fix interpreter version resolution

### DIFF
--- a/packages/wasm/scripts/gen-meta.sh
+++ b/packages/wasm/scripts/gen-meta.sh
@@ -1,4 +1,21 @@
 #!/bin/bash
+
+# Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 set -e
 
 # Generates `packages/wasm/dist/ballerina-meta.json` from the submodule state.

--- a/packages/wasm/scripts/gen-meta.sh
+++ b/packages/wasm/scripts/gen-meta.sh
@@ -30,7 +30,9 @@ resolve_tag() {
 TAG=$(resolve_tag)
 
 if [ -z "$TAG" ] && git remote get-url origin >/dev/null 2>&1; then
-  git fetch --tags --force --quiet origin >/dev/null 2>&1 || true
+  if ! git fetch --tags --quiet origin >/dev/null 2>&1; then
+    echo "warn: failed to fetch tags from origin; falling back to commit metadata" >&2
+  fi
   TAG=$(resolve_tag)
 fi
 

--- a/packages/wasm/scripts/gen-meta.sh
+++ b/packages/wasm/scripts/gen-meta.sh
@@ -16,14 +16,23 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -e
-
 # Generates `packages/wasm/dist/ballerina-meta.json` from the submodule state.
 # Uses an exact tag when available; otherwise records the current commit hash.
 
+set -e
+
 cd "$(dirname "$0")/../ballerina-lang-go"
 
-TAG=$(git describe --tags --exact-match 2>/dev/null || true)
+resolve_tag() {
+  git describe --tags --exact-match 2>/dev/null || true
+}
+
+TAG=$(resolve_tag)
+
+if [ -z "$TAG" ] && git remote get-url origin >/dev/null 2>&1; then
+  git fetch --tags --force --quiet origin >/dev/null 2>&1 || true
+  TAG=$(resolve_tag)
+fi
 
 if [ -n "$TAG" ]; then
   VERSION="$TAG"


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fix interpreter version resolution and add license header

This pull request improves reliability of interpreter version detection used by the Ballerina metadata generation script and adds/updates the file license header.

Changes
- Add license header to packages/wasm/scripts/gen-meta.sh.
- Enhance tag resolution in gen-meta.sh:
  - Introduce a resolve_tag() helper that encapsulates exact-match tag lookup.
  - Attempt local tag resolution; if none found and an origin remote exists, fetch remote tags (quiet, forced) and retry resolution.
  - Preserve existing behavior: if a tag is found the script records the tag as the version and marks type "tag"; otherwise it records the short commit hash and marks type "commit".
- Output remains unchanged: writes version, type, and full commit hash to packages/wasm/dist/ballerina-meta.json.

Outcome
- More robust build metadata generation: the script reliably determines the interpreter version from git tags even when tags are not present locally by fetching remote tags as needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->