### PR TITLE
Update GitHub link text display for mobile

### DIFF
--- a/apps/web/src/components/editor.tsx
+++ b/apps/web/src/components/editor.tsx
@@ -189,7 +189,7 @@ function EditorHeader() {
 					rel="noopener noreferrer"
 				>
 					<HugeiconsIcon icon={GithubFreeIcons} strokeWidth={1.5} size={16} />
-					<span>GitHub</span>
+					<span className="sm:block hidden">GitHub</span>
 				</a>
 			</div>
 		</header>


### PR DESCRIPTION
## Purpose
$subject


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updated the GitHub link text display in the editor header to be responsive to screen size. The GitHub text label now appears only on smaller medium breakpoints and larger, and is hidden by default on mobile devices, improving the mobile interface layout.

**Changes:**
- Modified `apps/web/src/components/editor.tsx` to add responsive styling (`sm:block hidden`) to the GitHub link text span in the EditorHeader component

**Impact:**
- Low effort change affecting only display logic
- No breaking changes to public APIs or exported entities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->