### PR TITLE
Refactor CodeEditor to CodeMirror

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,13 @@
 	},
 	"dependencies": {
 		"@base-ui/react": "^1.3.0",
+		"@codemirror/autocomplete": "^6.20.1",
+		"@codemirror/commands": "^6.10.3",
+		"@codemirror/language": "^6.12.3",
+		"@codemirror/legacy-modes": "^6.5.2",
+		"@codemirror/search": "^6.6.0",
+		"@codemirror/state": "^6.6.0",
+		"@codemirror/view": "^6.41.0",
 		"@fontsource-variable/jetbrains-mono": "^5.2.8",
 		"@hugeicons/core-free-icons": "^4.1.1",
 		"@hugeicons/react": "^1.1.6",
@@ -18,11 +25,12 @@
 		"@tanstack/react-router": "^1.168.10",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
+		"codemirror": "^6.0.2",
 		"immer": "^11.1.4",
 		"react": "^19.2.4",
 		"react-dom": "^19.2.4",
 		"react-hotkeys-hook": "^5.2.4",
-		"shadcn": "^4.1.2",
+		"shadcn": "^4.2.0",
 		"shiki": "^4.0.2",
 		"sonner": "^2.0.7",
 		"tailwind-merge": "^3.5.0",
@@ -37,7 +45,8 @@
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^6.0.1",
 		"globals": "^17.4.0",
+		"style-mod": "^4.1.3",
 		"typescript": "~6.0.2",
-		"vite": "^8.0.4"
+		"vite": "^8.0.7"
 	}
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
 		"@fontsource-variable/jetbrains-mono": "^5.2.8",
 		"@hugeicons/core-free-icons": "^4.1.1",
 		"@hugeicons/react": "^1.1.6",
+		"@replit/codemirror-vim": "^6.3.0",
 		"@tailwindcss/vite": "^4.2.1",
 		"@tanstack/react-router": "^1.168.10",
 		"class-variance-authority": "^0.7.1",

--- a/apps/web/src/components/code-editor.tsx
+++ b/apps/web/src/components/code-editor.tsx
@@ -1,164 +1,156 @@
 import * as React from "react";
 
-import { createHighlighter } from "shiki";
+import { basicSetup } from "codemirror";
+import { Prec } from "@codemirror/state";
+import { indentUnit } from "@codemirror/language";
+import { autocompletion } from "@codemirror/autocomplete";
+import { EditorView, keymap } from "@codemirror/view";
+import { indentWithTab } from "@codemirror/commands";
+
+import { ShikiEditor } from "@/components/shiki-editor";
 
 import { cn } from "@/lib/utils";
 
-import type { BundledLanguage, BundledTheme, HighlighterGeneric } from "shiki";
+import type { KeyBinding } from "@codemirror/view";
+import type { Extension } from "@codemirror/state";
+
+export type EditorLanguage = "ballerina" | "toml" | "text";
+
+type HotkeyMap = Record<string, () => void>;
 
 interface CodeEditorProps {
 	value?: string;
 	onChange?: (value: string) => void;
-	language?: string;
+	hotkeys?: HotkeyMap;
+	language?: EditorLanguage;
 	className?: string;
 }
 
-const sharedClasses =
-	"p-4 leading-[22.5px] font-sans whitespace-pre overflow-auto absolute inset-0 box-border [tab-size:2]";
+const INDENT = "    ";
 
-function escapeHtml(html: string) {
-	return html
-		.replace(/&/g, "&amp;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;")
-		.replace(/"/g, "&quot;")
-		.replace(/'/g, "&#039;");
+function buildHotkeyExtension(hotkeysRef: React.RefObject<HotkeyMap>) {
+	const bindings: KeyBinding[] = Object.keys(hotkeysRef.current ?? {}).map(
+		(key) => ({
+			key,
+			run: () => {
+				hotkeysRef.current?.[key]?.();
+				return true;
+			},
+		}),
+	);
+
+	return Prec.highest(keymap.of(bindings));
 }
 
+function baseExtensions(hotkeysRef: React.RefObject<HotkeyMap>): Extension[] {
+	return [
+		buildHotkeyExtension(hotkeysRef),
+		basicSetup,
+		indentUnit.of(INDENT),
+		keymap.of([indentWithTab]),
+		theme,
+		autocompletion({
+			activateOnTyping: false,
+			override: [],
+		}),
+	];
+}
+
+const theme = EditorView.theme({
+	"&": {
+		fontSize: "12.5px",
+		height: "100%",
+	},
+	".cm-scroller": {
+		fontFamily: "var(--font-sans), ui-monospace, monospace",
+		overflow: "auto",
+		scrollbarWidth: "none",
+		msOverflowStyle: "none",
+	},
+	".cm-scroller::-webkit-scrollbar": {
+		display: "none",
+	},
+	".cm-content": {
+		paddingTop: "1rem",
+		lineHeight: "180%",
+	},
+	".cm-line": {
+		lineHeight: "inherit",
+	},
+	".cm-gutters": {
+		paddingLeft: "0.5rem",
+		backgroundColor: "transparent",
+		border: "none",
+		color: "var(--muted-foreground)",
+		userSelect: "none",
+	},
+	".cm-activeLineGutter": {
+		backgroundColor: "transparent",
+	},
+	".cm-activeLine": {
+		backgroundColor: "transparent",
+	},
+	"&.cm-focused .cm-selectionBackground": {
+		backgroundColor: "rgba(59, 130, 246, 0.1) !important",
+	},
+	".cm-matchingBracket, .cm-nonmatchingBracket": {
+		outline: "none",
+		borderRadius: "0",
+	},
+});
+
 export function CodeEditor({
-	value = "",
+	value,
 	onChange,
+	hotkeys = {},
 	language = "ballerina",
 	className,
 }: CodeEditorProps) {
-	const [highlighted, setHighlighted] = React.useState("");
-	const highlighterRef = React.useRef<HighlighterGeneric<
-		BundledLanguage,
-		BundledTheme
-	> | null>(null);
-	const textareaRef = React.useRef<HTMLTextAreaElement>(null);
-	const preRef = React.useRef<HTMLPreElement>(null);
+	const parentRef = React.useRef<HTMLDivElement>(null);
+	const editorRef = React.useRef<ShikiEditor | null>(null);
 
-	const renderHighlight = React.useCallback(
-		(
-			code: string,
-			hl?: HighlighterGeneric<BundledLanguage, BundledTheme> | null,
-		) => {
-			const instance = hl || highlighterRef.current;
-			if (!instance) return;
+	const onChangeRef = React.useRef(onChange);
+	onChangeRef.current = onChange;
 
-			try {
-				const html = instance.codeToHtml(code || " ", {
-					lang: language,
-					theme: "github-light",
-				});
-				const inner = html
-					.replace(/^<pre[^>]*><code[^>]*>/, "")
-					.replace(/<\/code><\/pre>$/, "");
-				setHighlighted(inner);
-			} catch {
-				setHighlighted(escapeHtml(code));
-			}
-		},
-		[language],
-	);
+	const hotkeysRef = React.useRef(hotkeys);
+	hotkeysRef.current = hotkeys;
 
+	// biome-ignore lint/correctness/useExhaustiveDependencies: editor is recreated only on lang change; value is synced separately
 	React.useEffect(() => {
-		let isMounted = true;
+		const parent = parentRef.current;
+		if (!parent) return;
 
-		async function initShiki() {
-			try {
-				const hl = await createHighlighter({
-					themes: ["github-light"],
-					langs: ["ballerina", "toml"],
-				});
+		const editor = new ShikiEditor({
+			parent,
+			doc: value,
+			lang: language,
+			themes: {
+				light: "github-light",
+			},
+			defaultColor: "light",
+			themeStyle: "cm",
+			onUpdate: (update) => {
+				if (update.docChanged)
+					onChangeRef.current?.(update.state.doc.toString());
+			},
+			extensions: baseExtensions(hotkeysRef),
+		});
 
-				if (isMounted) {
-					highlighterRef.current = hl;
-					renderHighlight(textareaRef.current?.value ?? "", hl);
-				}
-			} catch {
-				if (isMounted)
-					setHighlighted(escapeHtml(textareaRef.current?.value ?? ""));
-			}
-		}
+		editorRef.current = editor;
 
-		initShiki();
 		return () => {
-			isMounted = false;
-			highlighterRef.current?.dispose();
-			highlighterRef.current = null;
+			editorRef.current?.destroy();
+			editorRef.current = null;
 		};
-	}, [renderHighlight]);
-
-	React.useEffect(() => {
-		renderHighlight(value);
-	}, [value, renderHighlight]);
-
-	const syncScroll = React.useCallback(() => {
-		if (textareaRef.current && preRef.current) {
-			preRef.current.scrollTop = textareaRef.current.scrollTop;
-			preRef.current.scrollLeft = textareaRef.current.scrollLeft;
-		}
 	}, []);
-
-	const handleKeyDown = React.useCallback(
-		(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-			if (e.key !== "Tab") return;
-
-			e.preventDefault();
-			const target = e.currentTarget;
-			const { selectionStart, selectionEnd, value: currentValue } = target;
-
-			const newValue =
-				currentValue.slice(0, selectionStart) +
-				"    " +
-				currentValue.slice(selectionEnd);
-			onChange?.(newValue);
-
-			setTimeout(() => {
-				if (textareaRef.current) {
-					textareaRef.current.setSelectionRange(
-						selectionStart + 4,
-						selectionStart + 4,
-					);
-				}
-			}, 0);
-		},
-		[onChange],
-	);
 
 	return (
 		<div
+			ref={parentRef}
 			className={cn(
-				"text-[13px] relative flex overflow-hidden h-full min-h-37.5",
+				"relative overflow-hidden h-full min-h-37.5 cm-editor-host",
 				className,
 			)}
-		>
-			<div className="relative grow">
-				<pre
-					ref={preRef}
-					aria-hidden="true"
-					className={cn(sharedClasses, "z-10 pointer-events-none no-scrollbar")}
-					// biome-ignore lint/security/noDangerouslySetInnerHtml: content is sanitized via Shiki's HTML escaping
-					dangerouslySetInnerHTML={{ __html: `${highlighted}\n` }}
-				/>
-				<textarea
-					ref={textareaRef}
-					value={value}
-					onChange={(e) => onChange?.(e.target.value)}
-					onScroll={syncScroll}
-					onKeyDown={handleKeyDown}
-					spellCheck={false}
-					autoCapitalize="off"
-					autoComplete="off"
-					autoCorrect="off"
-					className={cn(
-						sharedClasses,
-						"z-20 bg-transparent text-transparent caret-blue-500 outline-none resize-none no-scrollbar",
-					)}
-				/>
-			</div>
-		</div>
+		/>
 	);
 }

--- a/apps/web/src/components/code-editor.tsx
+++ b/apps/web/src/components/code-editor.tsx
@@ -1,13 +1,18 @@
 import * as React from "react";
 
 import { basicSetup } from "codemirror";
-import { Prec } from "@codemirror/state";
-import { indentUnit } from "@codemirror/language";
+import { Compartment, Prec } from "@codemirror/state";
+import { StreamLanguage, indentUnit } from "@codemirror/language";
 import { autocompletion } from "@codemirror/autocomplete";
 import { EditorView, keymap } from "@codemirror/view";
 import { indentWithTab } from "@codemirror/commands";
+import { clike } from "@codemirror/legacy-modes/mode/clike";
+import { Vim, vim } from "@replit/codemirror-vim";
 
 import { ShikiEditor } from "@/components/shiki-editor";
+
+import { useEditorStore } from "@/stores/editor-store";
+import { useFileTreeActions } from "@/stores/file-tree-store";
 
 import { cn } from "@/lib/utils";
 
@@ -27,6 +32,14 @@ interface CodeEditorProps {
 }
 
 const INDENT = "    ";
+
+// This is a hack to bring smart indentation for Ballerina
+// since there's no official CodeMirror support
+const ballerinaMode = StreamLanguage.define(
+	clike({
+		name: "ballerina",
+	}),
+);
 
 function buildHotkeyExtension(hotkeysRef: React.RefObject<HotkeyMap>) {
 	const bindings: KeyBinding[] = Object.keys(hotkeysRef.current ?? {}).map(
@@ -53,6 +66,7 @@ function baseExtensions(hotkeysRef: React.RefObject<HotkeyMap>): Extension[] {
 			activateOnTyping: false,
 			override: [],
 		}),
+		ballerinaMode,
 	];
 }
 
@@ -97,6 +111,16 @@ const theme = EditorView.theme({
 		outline: "none",
 		borderRadius: "0",
 	},
+	".cm-vim-panel": {
+		backgroundColor: "var(--background)",
+		color: "var(--foreground)",
+	},
+	".cm-vim-panel input": {
+		fontFamily: "var(--font-sans), ui-monospace, monospace !important",
+	},
+	".cm-vim-message": {
+		color: "var(--muted-foreground) !important",
+	},
 });
 
 export function CodeEditor({
@@ -109,11 +133,19 @@ export function CodeEditor({
 	const parentRef = React.useRef<HTMLDivElement>(null);
 	const editorRef = React.useRef<ShikiEditor | null>(null);
 
+	const vimCompartment = React.useRef(new Compartment());
+
 	const onChangeRef = React.useRef(onChange);
 	onChangeRef.current = onChange;
 
 	const hotkeysRef = React.useRef(hotkeys);
 	hotkeysRef.current = hotkeys;
+
+	const vimEnabled = useEditorStore((s) => s.editorMode) === "vim";
+
+	const { saveFile } = useFileTreeActions();
+
+	Vim.defineEx("write", "w", () => saveFile());
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: editor is recreated only on lang change; value is synced separately
 	React.useEffect(() => {
@@ -133,7 +165,10 @@ export function CodeEditor({
 				if (update.docChanged)
 					onChangeRef.current?.(update.state.doc.toString());
 			},
-			extensions: baseExtensions(hotkeysRef),
+			extensions: [
+				...baseExtensions(hotkeysRef),
+				vimCompartment.current.of(vimEnabled ? vim() : []),
+			],
 		});
 
 		editorRef.current = editor;
@@ -143,6 +178,12 @@ export function CodeEditor({
 			editorRef.current = null;
 		};
 	}, []);
+
+	React.useEffect(() => {
+		const editor = editorRef.current;
+		if (!editor) return;
+		editor.reconfigure(vimCompartment.current, vimEnabled ? vim() : []);
+	}, [vimEnabled]);
 
 	return (
 		<div

--- a/apps/web/src/components/code-editor.tsx
+++ b/apps/web/src/components/code-editor.tsx
@@ -145,7 +145,8 @@ export function CodeEditor({
 
 	const { saveFile } = useFileTreeActions();
 
-	Vim.defineEx("write", "w", () => saveFile());
+	const saveFileRef = React.useRef(saveFile);
+	saveFileRef.current = saveFile;
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: editor is recreated only on lang change; value is synced separately
 	React.useEffect(() => {
@@ -196,6 +197,10 @@ export function CodeEditor({
 		if (!editor) return;
 		editor.reconfigure(vimCompartment.current, vimEnabled ? vim() : []);
 	}, [vimEnabled]);
+
+	React.useEffect(() => {
+		Vim.defineEx("write", "w", () => saveFileRef.current?.());
+	}, []);
 
 	return (
 		<div

--- a/apps/web/src/components/code-editor.tsx
+++ b/apps/web/src/components/code-editor.tsx
@@ -66,7 +66,6 @@ function baseExtensions(hotkeysRef: React.RefObject<HotkeyMap>): Extension[] {
 			activateOnTyping: false,
 			override: [],
 		}),
-		ballerinaMode,
 	];
 }
 
@@ -133,6 +132,7 @@ export function CodeEditor({
 	const parentRef = React.useRef<HTMLDivElement>(null);
 	const editorRef = React.useRef<ShikiEditor | null>(null);
 
+	const languageCompartment = React.useRef(new Compartment());
 	const vimCompartment = React.useRef(new Compartment());
 
 	const onChangeRef = React.useRef(onChange);
@@ -167,6 +167,9 @@ export function CodeEditor({
 			},
 			extensions: [
 				...baseExtensions(hotkeysRef),
+				languageCompartment.current.of(
+					language === "ballerina" ? ballerinaMode : [],
+				),
 				vimCompartment.current.of(vimEnabled ? vim() : []),
 			],
 		});
@@ -178,6 +181,15 @@ export function CodeEditor({
 			editorRef.current = null;
 		};
 	}, []);
+
+	React.useEffect(() => {
+		const editor = editorRef.current;
+		if (!editor) return;
+		editor.reconfigure(
+			languageCompartment.current,
+			language === "ballerina" ? ballerinaMode : [],
+		);
+	}, [language]);
 
 	React.useEffect(() => {
 		const editor = editorRef.current;

--- a/apps/web/src/components/editor.tsx
+++ b/apps/web/src/components/editor.tsx
@@ -39,8 +39,9 @@ import { useBallerina } from "@/hooks/use-ballerina";
 import { useFS } from "@/providers/fs-provider";
 
 import type { LayeredFS } from "@/lib/fs/layered-fs";
+import type { EditorLanguage } from "@/components/code-editor";
 
-function getLanguage(path: string): string {
+function getLanguage(path: string): EditorLanguage {
 	const ex = ext(path);
 	switch (ex) {
 		case "bal":
@@ -163,12 +164,17 @@ function EditorPane({ onRun }: { onRun: () => void }) {
 					<span>Run</span>
 				</Button>
 			</div>
-			<CodeEditor
-				className="flex-1 min-h-0 w-full"
-				value={activeFile?.content ?? ""}
-				onChange={handleChange}
-				language={activeFile ? getLanguage(activeFile.path) : undefined}
-			/>
+			{activeFile && (
+				<CodeEditor
+					key={activeFile.path}
+					value={activeFile?.content}
+					onChange={handleChange}
+					hotkeys={{
+						"Mod-Enter": onRun,
+					}}
+					language={activeFile ? getLanguage(activeFile.path) : "text"}
+				/>
+			)}
 		</div>
 	);
 }

--- a/apps/web/src/components/editor.tsx
+++ b/apps/web/src/components/editor.tsx
@@ -134,6 +134,7 @@ function EditorPane({ onRun }: { onRun: () => void }) {
 	const { updateFileContent } = useFileTreeActions();
 
 	const outputOpen = useEditorStore((s) => s.outputOpen);
+	const toggleEditorMode = useEditorStore((s) => s.toggleEditorMode);
 
 	const handleChange = React.useCallback(
 		(next: string) => {
@@ -171,6 +172,8 @@ function EditorPane({ onRun }: { onRun: () => void }) {
 					onChange={handleChange}
 					hotkeys={{
 						"Mod-Enter": onRun,
+						"Mod-Alt-v": toggleEditorMode,
+						"Mod-r": () => window.location.reload(),
 					}}
 					language={activeFile ? getLanguage(activeFile.path) : "text"}
 				/>
@@ -212,6 +215,7 @@ function EditorContent() {
 	const { saveFile } = useFileTreeActions();
 
 	const openOutputWith = useEditorStore((s) => s.openOutputWith);
+	const toggleEditorMode = useEditorStore((s) => s.toggleEditorMode);
 
 	const handleRun = React.useCallback(() => {
 		if (!activeFile || getLanguage(activeFile.path) !== "ballerina") return;
@@ -240,17 +244,13 @@ function EditorContent() {
 		openOutputWith(captured);
 	}, [activeFile, fs, saveFile, run, openOutputWith]);
 
-	useHotkeys(
-		"mod+enter",
-		(e) => {
-			e.preventDefault();
-			handleRun();
-		},
-		{
-			enableOnFormTags: ["TEXTAREA"],
-			preventDefault: true,
-		},
-	);
+	useHotkeys("mod+enter", () => handleRun(), {
+		preventDefault: true,
+	});
+
+	useHotkeys("mod+alt+v", () => toggleEditorMode(), {
+		preventDefault: true,
+	});
 
 	if (!isReady) return <WasmLoadingScreen progress={progress} />;
 

--- a/apps/web/src/components/shiki-editor.ts
+++ b/apps/web/src/components/shiki-editor.ts
@@ -1,0 +1,1219 @@
+import {
+	type Text,
+	Compartment,
+	RangeSet,
+	RangeSetBuilder,
+	StateEffect,
+	type Extension,
+} from "@codemirror/state";
+import {
+	type DecorationSet,
+	type EditorViewConfig,
+	type ViewUpdate,
+	Decoration,
+	EditorView,
+	ViewPlugin,
+} from "@codemirror/view";
+import { createHighlighter } from "shiki";
+import { StyleModule } from "style-mod";
+
+import type { StyleSpec } from "style-mod";
+
+type ThemeRegistry = Record<string, string | Record<string, unknown>>;
+
+type Highlighter = Record<string, unknown>;
+
+type InitShikiFn = (
+	options: Omit<ShikiToCMOptions, "theme">,
+) => Promise<Highlighter>;
+
+interface Options<TThemes extends ThemeRegistry = ThemeRegistry> {
+	lang?: string | unknown;
+	theme?: string;
+	themes?: TThemes;
+	themeStyle?: "cm" | "shiki";
+	defaultColor?: (keyof TThemes & string) | (string & {}) | false;
+	langAlias?: Record<string, string>;
+	warnings?: boolean;
+	versionGuard?: boolean;
+	cssVariablePrefix?: string;
+	tokenizeMaxLineLength?: number;
+	includeExplanation?: boolean;
+	tokenizeTimeLimit?: number;
+	highlighter?: Highlighter;
+	resolveLang?: unknown;
+	resolveTheme?: unknown;
+}
+
+interface ShikiToCMOptions<TThemes extends ThemeRegistry = ThemeRegistry>
+	extends Required<
+		Omit<
+			Options<TThemes>,
+			| "theme"
+			| "langAlias"
+			| "colorReplacements"
+			| "grammarState"
+			| "grammarContextCode"
+			| "highlighter"
+			| "versionGuard"
+			| "resolveLang"
+			| "resolveTheme"
+		>
+	> {
+	lang: string | unknown;
+	langAlias?: Record<string, string>;
+	highlighter?: Highlighter;
+	versionGuard?: boolean;
+	resolveLang?: unknown;
+	resolveTheme?: unknown;
+}
+
+export interface ShikiEditorOptions<
+	TThemes extends ThemeRegistry = ThemeRegistry,
+> extends Omit<EditorViewConfig, "extensions" | "doc" | "parent"> {
+	parent: HTMLElement;
+	doc?: string;
+	extensions?: Extension | readonly Extension[];
+	lang: string | unknown;
+	/** Single-theme shorthand; merged into `themes.light` by the bridge if used */
+	theme?: string;
+	themes?: TThemes;
+	defaultColor?: Options<TThemes>["defaultColor"];
+	themeStyle?: "cm" | "shiki";
+	onUpdate?: (update: ViewUpdate) => void;
+}
+
+interface ThemeSettings {
+	background?: string;
+	backgroundImage?: string;
+	foreground?: string;
+	caret?: string;
+	selection?: string;
+	selectionMatch?: string;
+	lineHighlight?: string;
+	gutterBackground?: string;
+	gutterForeground?: string;
+	gutterActiveForeground?: string;
+	gutterBorder?: string;
+	fontFamily?: string;
+	fontSize?: StyleSpec["fontSize"];
+}
+
+interface CreateThemeOptions {
+	theme: "light" | "dark";
+	settings: ThemeSettings;
+	classes?: { [selector: string]: StyleSpec };
+}
+
+function getClasses(view: EditorView): string[] {
+	return view.themeClasses.split(" ").filter((id) => !!id.trim());
+}
+
+function mountStyles(
+	view: EditorView,
+	spec: { [selector: string]: StyleSpec },
+	scopes?: Record<string, string>,
+) {
+	return StyleModule.mount(
+		view.root,
+		new StyleModule(spec, {
+			finish(sel) {
+				const main = `.${getClasses(view)[0]}`;
+				return /&/.test(sel)
+					? sel.replace(/&\w*/, (m) => {
+							if (m === "&") return main;
+							if (!scopes?.[m])
+								throw new RangeError(`Unsupported selector: ${m}`);
+							return scopes[m];
+						})
+					: `${main} ${sel}`;
+			},
+		}),
+	);
+}
+
+function newStyleModuleName(): string {
+	return StyleModule.newName();
+}
+
+function createTheme({
+	theme,
+	settings,
+	classes,
+}: CreateThemeOptions): Extension {
+	settings = {
+		caret: "#FFFFFF",
+		...settings,
+	};
+	let themeOptions: Record<string, StyleSpec> = {
+		".cm-gutters": {},
+	};
+	const baseStyle: StyleSpec = {};
+	if (settings.background) baseStyle.backgroundColor = settings.background;
+	if (settings.backgroundImage)
+		baseStyle.backgroundImage = settings.backgroundImage;
+	if (settings.foreground) baseStyle.color = settings.foreground;
+	if (settings.fontSize) baseStyle.fontSize = settings.fontSize;
+	if (settings.background || settings.foreground) {
+		themeOptions["&"] = baseStyle;
+	}
+	if (settings.fontFamily) {
+		themeOptions["&.cm-editor .cm-scroller"] = {
+			fontFamily: settings.fontFamily,
+		};
+	}
+	if (settings.gutterBackground) {
+		themeOptions[".cm-gutters"].backgroundColor = settings.gutterBackground;
+	}
+	if (settings.gutterForeground) {
+		themeOptions[".cm-gutters"].color = settings.gutterForeground;
+	}
+	if (settings.gutterBorder) {
+		themeOptions[".cm-gutters"].borderRightColor = settings.gutterBorder;
+	}
+	if (settings.caret) {
+		themeOptions[".cm-content"] = { caretColor: settings.caret };
+		themeOptions[".cm-cursor, .cm-dropCursor"] = {
+			borderLeftColor: settings.caret,
+		};
+	}
+	const activeLineGutterStyle: StyleSpec = {};
+	if (settings.gutterActiveForeground) {
+		activeLineGutterStyle.color = settings.gutterActiveForeground;
+	}
+	const cmEditorStyle: StyleSpec = {};
+	if (settings.lineHighlight) {
+		cmEditorStyle["& .cm-activeLine"] = {
+			backgroundColor: "transparent",
+		};
+		activeLineGutterStyle.backgroundColor = settings.lineHighlight;
+	}
+	themeOptions[".cm-activeLineGutter"] = activeLineGutterStyle;
+	if (settings.selection) {
+		cmEditorStyle["& .cm-selectionLayer"] = { zIndex: 2 };
+		cmEditorStyle["& .cm-cursorLayer"] = { zIndex: 3 };
+		cmEditorStyle["& .cm-line"] = {
+			"& ::selection, &::selection": { backgroundColor: settings.selection },
+			"& span::selection": { backgroundColor: settings.selection },
+		};
+		cmEditorStyle[
+			"& .cm-selectionBackground, & .cm-selectionLayer .cm-selectionBackground"
+		] = {
+			backgroundColor: `${settings.selection} !important`,
+		};
+		cmEditorStyle[
+			"&:has(.cm-selectionLayer .cm-selectionBackground) .cm-activeLine"
+		] = {
+			backgroundColor: "transparent !important",
+		};
+	}
+	if (Object.keys(cmEditorStyle).length > 0) {
+		themeOptions["&.cm-editor"] = cmEditorStyle;
+	}
+	if (settings.selectionMatch) {
+		themeOptions["& .cm-selectionMatch"] = {
+			backgroundColor: settings.selectionMatch,
+		};
+	}
+	if (classes) themeOptions = { ...themeOptions, ...classes };
+	return EditorView.theme(themeOptions, { dark: theme === "dark" });
+}
+
+function toStyleObject(styleStr: string, isBgStyle = false, important = false) {
+	const Styles: Record<string, string> = {};
+	const suffix = important ? " !important" : "";
+	for (const part of styleStr.split(";")) {
+		const [k, v] = part.split(":");
+		if (k && v) Styles[k.trim()] = `${v.trim()}${suffix}`;
+		else if (isBgStyle) Styles["background-color"] = `${k?.trim()}${suffix}`;
+		else if (k) Styles.color = `${k.trim()}${suffix}`;
+	}
+	return Styles;
+}
+
+function normalizeRuntimeLangs(value: unknown): unknown[] {
+	const out: unknown[] = [];
+	function push(v: unknown) {
+		if (v == null) return;
+		if (Array.isArray(v)) {
+			for (const x of v) push(x);
+			return;
+		}
+		out.push(v);
+	}
+	push(value);
+	return out;
+}
+
+function getPrimaryRuntimeLangId(value: unknown): string | undefined {
+	const first = normalizeRuntimeLangs(value)[0];
+	if (first == null) return undefined;
+	if (typeof first === "string") return first;
+	if (typeof first === "object" && first !== null) {
+		const o = first as Record<string, unknown>;
+		const name = o.name;
+		const scopeName = o.scopeName;
+		if (typeof name === "string" && name.length > 0) return name;
+		if (typeof scopeName === "string" && scopeName.length > 0) return scopeName;
+		return "custom-lang";
+	}
+	return undefined;
+}
+
+function getRuntimeLangLabel(value: unknown): string {
+	if (typeof value === "string") return value;
+	if (value && typeof value === "object") {
+		const o = value as Record<string, unknown>;
+		if (typeof o.name === "string" && o.name.length > 0) return o.name;
+		if (typeof o.scopeName === "string" && o.scopeName.length > 0)
+			return o.scopeName;
+		return "custom-lang";
+	}
+	return "unknown-lang";
+}
+
+function assertCompatibleHighlighter(
+	highlighter: unknown,
+	source: string,
+	warnings = true,
+	enabled = true,
+): asserts highlighter is Highlighter {
+	if (!enabled) return;
+	if (!highlighter || typeof highlighter !== "object") {
+		throw new Error(
+			`${source} Incompatible highlighter. Use createHighlighter from shiki.`,
+		);
+	}
+	const value = highlighter as Record<string, unknown>;
+	for (const method of ["getLanguage", "getTheme", "setTheme"]) {
+		if (typeof value[method] !== "function") {
+			throw new Error(
+				`${source} Incompatible highlighter. Missing method: ${method}.`,
+			);
+		}
+	}
+	if (
+		(typeof value.loadLanguage !== "function" ||
+			typeof value.loadTheme !== "function") &&
+		warnings
+	) {
+		console.warn(
+			`${source} Highlighter misses optional loadLanguage/loadTheme; dynamic loads may be partial.`,
+		);
+	}
+}
+
+const defaultShikiOptions = {
+	lang: "text",
+	warnings: true,
+	versionGuard: true,
+	themeStyle: "shiki" as const,
+	defaultColor: "light" as const,
+	cssVariablePrefix: "--shiki-",
+	tokenizeMaxLineLength: 20000,
+	includeExplanation: false,
+	tokenizeTimeLimit: 500,
+};
+
+const themeCompartment = new Compartment();
+
+type ThemeName = string;
+
+class Base {
+	protected themesCache = new Map<ThemeName, Extension>();
+	protected currentTheme = "light";
+	private readonly initShikiFn: InitShikiFn;
+
+	get isCmStyle() {
+		return this.configs.themeStyle === "cm";
+	}
+
+	constructor(
+		protected shikiCore: Highlighter,
+		protected configs: ShikiToCMOptions,
+		initShikiFn?: InitShikiFn,
+	) {
+		this.initShikiFn = initShikiFn ?? (async () => this.shikiCore);
+		this.loadThemes();
+	}
+
+	initTheme(): Extension {
+		const { defaultColor, themes, warnings } = this.configs;
+		if (defaultColor === false) return EditorView.baseTheme({});
+
+		const hasColorKey = (key: string) => Boolean(themes?.[key]);
+		const fallbackColor = hasColorKey("dark")
+			? "dark"
+			: hasColorKey("light")
+				? "light"
+				: Object.keys(themes || {})[0] || "light";
+
+		let resolvedColor = fallbackColor;
+		if (typeof defaultColor === "string" && hasColorKey(defaultColor)) {
+			resolvedColor = defaultColor;
+		} else if (typeof defaultColor === "string" && warnings) {
+			console.warn(
+				`[shiki-editor] defaultColor "${defaultColor}" is invalid; using "${fallbackColor}".`,
+			);
+		}
+		this.currentTheme = resolvedColor;
+		return this.getTheme(this.currentTheme);
+	}
+
+	async update(options: Partial<Options>, view: EditorView) {
+		const prev = { ...this.configs };
+		this.configs = { ...this.configs, ...options };
+
+		const shouldReload =
+			(options.themes !== undefined &&
+				JSON.stringify(options.themes) !== JSON.stringify(prev.themes)) ||
+			(options.defaultColor !== undefined &&
+				prev.defaultColor !== options.defaultColor) ||
+			(options.lang !== undefined && prev.lang !== options.lang) ||
+			(options.langAlias !== undefined &&
+				JSON.stringify(options.langAlias) !== JSON.stringify(prev.langAlias)) ||
+			(options.highlighter !== undefined &&
+				prev.highlighter !== options.highlighter) ||
+			(options.warnings !== undefined && prev.warnings !== options.warnings);
+
+		if (shouldReload) {
+			this.shikiCore = await this.initShikiFn(this.configs);
+			const raf =
+				typeof globalThis !== "undefined" && globalThis.requestAnimationFrame
+					? globalThis.requestAnimationFrame.bind(globalThis)
+					: (fn: () => void) => setTimeout(fn, 0);
+			raf(() => {
+				this.loadThemes();
+				view.dispatch({
+					effects: themeCompartment.reconfigure(this.initTheme()),
+				});
+			});
+		}
+	}
+
+	getTheme(name: string = this.currentTheme): Extension {
+		const ext = this.themesCache.get(name);
+		if (ext) {
+			this.currentTheme = name;
+			return ext;
+		}
+		throw new Error(`'${name}' theme is not registered!`);
+	}
+
+	loadThemes() {
+		const { themes } = this.configs;
+		for (const color of Object.keys(themes)) {
+			const name = themes[color];
+			if (!name) throw new Error(`'${String(name)}' theme is not registered!`);
+			const getter = this.shikiCore.getTheme as (n: string) => {
+				colors?: Record<string, string>;
+				bg: string;
+				fg: string;
+				type: "light" | "dark";
+			};
+			const { colors, bg, fg, type } = getter.call(
+				this.shikiCore,
+				name as string,
+			);
+			let settings: ThemeSettings = { background: bg, foreground: fg };
+			if (colors) {
+				const defaultSelection = type === "dark" ? "#264f78" : "#add6ff";
+				const selectionColor =
+					colors["editor.selectionBackground"] ||
+					colors["editor.wordHighlightBackground"] ||
+					defaultSelection;
+				settings = {
+					...settings,
+					gutterBackground: bg,
+					gutterForeground: fg,
+					gutterBorder: "transparent",
+					selection: selectionColor,
+					selectionMatch:
+						colors["editor.wordHighlightStrongBackground"] ||
+						colors["editor.selectionHighlightBackground"] ||
+						selectionColor,
+					caret:
+						colors["editorCursor.foreground"] || colors.foreground || "#FFFFFF",
+					lineHighlight:
+						colors["editor.lineHighlightBackground"] ||
+						(type === "dark" ? "#ffffff0a" : "#0000000a"),
+				};
+			}
+			this.themesCache.set(
+				color,
+				createTheme({ theme: type, settings, classes: undefined }),
+			);
+		}
+	}
+}
+
+const FONT_STYLE_MASK = 30720;
+const FONT_STYLE_OFFSET = 11;
+const FOREGROUND_MASK = 16744448;
+const FOREGROUND_OFFSET = 15;
+
+function getFontStyle(metadata: number): number {
+	return (metadata & FONT_STYLE_MASK) >>> FONT_STYLE_OFFSET;
+}
+
+function getForeground(metadata: number): number {
+	return (metadata & FOREGROUND_MASK) >>> FOREGROUND_OFFSET;
+}
+
+const CACHE_MAX_ENTRIES = 12000;
+const CACHE_KEEP_BEHIND_LINES = 3000;
+const CACHE_KEEP_AHEAD_LINES = 6000;
+const CACHE_ANCHOR_INTERVAL = 200;
+
+function computePrunableCacheLines(
+	lines: number[],
+	centerLine: number,
+	options: {
+		maxEntries?: number;
+		keepBehindLines?: number;
+		keepAheadLines?: number;
+		anchorInterval?: number;
+	} = {},
+): number[] {
+	const maxEntries = options.maxEntries ?? CACHE_MAX_ENTRIES;
+	const keepBehindLines = options.keepBehindLines ?? CACHE_KEEP_BEHIND_LINES;
+	const keepAheadLines = options.keepAheadLines ?? CACHE_KEEP_AHEAD_LINES;
+	const anchorInterval = options.anchorInterval ?? CACHE_ANCHOR_INTERVAL;
+	if (lines.length <= maxEntries) return [];
+	const keepStart = Math.max(1, centerLine - keepBehindLines);
+	const keepEnd = centerLine + keepAheadLines;
+	const mustKeep: number[] = [];
+	const removable: number[] = [];
+	for (const line of lines) {
+		const inWindow = line >= keepStart && line <= keepEnd;
+		const isAnchor = line % anchorInterval === 0;
+		if (inWindow || isAnchor) mustKeep.push(line);
+		else removable.push(line);
+	}
+	if (mustKeep.length <= maxEntries) return removable;
+	const over = mustKeep.length - maxEntries;
+	const fallbackRemovals = [...mustKeep]
+		.sort(
+			(a, b) => Math.abs(b - centerLine) - Math.abs(a - centerLine) || b - a,
+		)
+		.slice(0, over);
+	return removable.concat(fallbackRemovals);
+}
+
+class ShikiHighlighter extends Base {
+	view!: EditorView;
+	private grammarStateCache = new Map<number, unknown>();
+	private internal: Highlighter;
+	private isCoreUpdating = false;
+
+	constructor(
+		shikiCore: Highlighter,
+		options: ShikiToCMOptions,
+		initShikiFn?: InitShikiFn,
+	) {
+		super(shikiCore, options, initShikiFn);
+		this.internal = shikiCore;
+	}
+
+	setView(view: EditorView) {
+		this.view = view;
+		return this;
+	}
+
+	override async update(options: Partial<Options>, view: EditorView) {
+		this.grammarStateCache.clear();
+		this.isCoreUpdating = true;
+		try {
+			await super.update(options, view);
+			this.internal = this.shikiCore;
+		} finally {
+			this.isCoreUpdating = false;
+		}
+	}
+
+	highlight(
+		doc: Text,
+		from: number,
+		to: number,
+		buildDeco: (from: number, to: number, mark: Decoration) => void,
+		budgetOptions: { maxDecorations?: number } = {},
+	): { produced: number; nextFrom: number | null } {
+		let produced = 0;
+		let nextFrom: number | null = null;
+		const maxDecorations = budgetOptions.maxDecorations;
+		if (this.isCoreUpdating) return { produced, nextFrom };
+		if (!this.internal) {
+			console.warn("highlight: internal not ready");
+			return { produced, nextFrom };
+		}
+		const langId = getPrimaryRuntimeLangId(this.configs.lang);
+		const themeAlias = this.currentTheme;
+		const internal = this.internal;
+		if (!langId) {
+			if (this.configs.warnings)
+				console.warn("highlight: lang is not configured");
+			return { produced, nextFrom };
+		}
+		const validTheme = this.configs.themes[themeAlias];
+		if (!validTheme) {
+			console.warn(`highlight: theme '${themeAlias}' not in themes config`);
+			return { produced, nextFrom };
+		}
+		const finalThemeName =
+			typeof validTheme === "string"
+				? validTheme
+				: String((validTheme as { name?: string }).name);
+		const setTheme = internal.setTheme as (n: string) => { colorMap: string[] };
+		const { colorMap } = setTheme.call(internal, finalThemeName);
+		let grammar: {
+			tokenizeLine2: (
+				line: string,
+				state: unknown,
+			) => { tokens: Uint32Array; ruleStack: unknown };
+		};
+		try {
+			grammar = (internal.getLanguage as (id: string) => typeof grammar)(
+				langId,
+			);
+		} catch (error) {
+			if (this.configs.warnings) {
+				console.warn(
+					`highlight: lang '${langId}' not ready, skip frame`,
+					error,
+				);
+			}
+			return { produced, nextFrom };
+		}
+		if (!grammar) {
+			if (this.configs.warnings)
+				console.warn(`highlight: grammar not found for langId=${langId}`);
+			return { produced, nextFrom };
+		}
+		const getTh = internal.getTheme as
+			| undefined
+			| ((n: string) => { fg?: string });
+		const themeForeground =
+			getTh?.call(internal, finalThemeName)?.fg ??
+			(this.shikiCore.getTheme as (n: string) => { fg: string }).call(
+				this.shikiCore,
+				finalThemeName,
+			).fg ??
+			"#000";
+		const defaultForeground = colorMap[1] || themeForeground;
+		const startLine = doc.lineAt(from).number;
+		const endLine = doc.lineAt(to).number;
+		const stateLine = startLine - 1;
+		let state: unknown;
+		if (stateLine >= 1) {
+			if (this.grammarStateCache.has(stateLine)) {
+				state = this.grammarStateCache.get(stateLine);
+			} else {
+				let nearest = 0;
+				for (let i = stateLine; i >= 1; i--) {
+					if (this.grammarStateCache.has(i)) {
+						nearest = i;
+						state = this.grammarStateCache.get(i);
+						break;
+					}
+				}
+				if (nearest < stateLine) {
+					let bridgeState = state;
+					for (let i = nearest + 1; i <= stateLine; i++) {
+						const lineContent = doc.line(i).text;
+						const result = grammar.tokenizeLine2(lineContent, bridgeState);
+						bridgeState = result.ruleStack;
+						if (bridgeState !== undefined && bridgeState !== null) {
+							this.grammarStateCache.set(i, bridgeState);
+						}
+					}
+					state = bridgeState;
+				}
+			}
+		}
+		const cmClasses: Record<string, string> = {};
+		const langLabel = getRuntimeLangLabel(this.configs.lang);
+		this.view.dom.classList.toggle(
+			`lang-${langLabel.replace(/[^\w-]/g, "_")}`,
+			true,
+		);
+		let currentState = state;
+		let lastProcessedLine = startLine - 1;
+		for (let i = startLine; i <= endLine; i++) {
+			if (maxDecorations !== undefined && produced >= maxDecorations) {
+				nextFrom = doc.line(i).from;
+				break;
+			}
+			const line = doc.line(i);
+			const result = grammar.tokenizeLine2(line.text, currentState);
+			currentState = result.ruleStack;
+			if (currentState !== undefined && currentState !== null) {
+				this.grammarStateCache.set(i, currentState);
+			}
+			const tokens = result.tokens;
+			const len = tokens.length / 2;
+			const pos = line.from;
+			for (let j = 0; j < len; j++) {
+				const startOffset = Number(tokens[2 * j]);
+				const metadata = Number(tokens[2 * j + 1]);
+				const endOffset =
+					j + 1 < len ? Number(tokens[2 * (j + 1)]) : line.text.length;
+				const foregroundId = getForeground(metadata);
+				const fontStyle = getFontStyle(metadata);
+				const color = colorMap[foregroundId] || defaultForeground;
+				let style = `color:${color}`;
+				if (fontStyle & 1) style += ";font-style:italic";
+				if (fontStyle & 2) style += ";font-weight:bold";
+				if (fontStyle & 4) style += ";text-decoration:underline";
+				const cls = cmClasses[style] || newStyleModuleName();
+				cmClasses[style] = cls;
+				const tokenFrom = pos + startOffset;
+				const tokenTo = pos + endOffset;
+				if (tokenFrom < tokenTo) {
+					const attributes: Record<string, string> = this.isCmStyle
+						? { class: cls }
+						: { style };
+					buildDeco(
+						tokenFrom,
+						tokenTo,
+						Decoration.mark({
+							tagName: "span",
+							attributes,
+						}),
+					);
+					produced++;
+				}
+			}
+			lastProcessedLine = i;
+			if (maxDecorations !== undefined && produced >= maxDecorations) {
+				if (i < endLine) nextFrom = doc.line(i + 1).from;
+				break;
+			}
+		}
+		const pruneCenterLine =
+			lastProcessedLine >= startLine ? lastProcessedLine : startLine;
+		for (const line of computePrunableCacheLines(
+			[...this.grammarStateCache.keys()],
+			pruneCenterLine,
+		)) {
+			this.grammarStateCache.delete(line);
+		}
+		if (this.isCmStyle) {
+			for (const [k, v] of Object.entries(cmClasses)) {
+				mountStyles(this.view, {
+					[`& .cm-line .${v}`]: toStyleObject(k, false) || {},
+				});
+			}
+		}
+		return { produced, nextFrom };
+	}
+}
+
+const updateEffect = StateEffect.define<Partial<Options>>();
+
+interface DecorationEntry {
+	from: number;
+	to: number;
+	mark: Decoration;
+}
+
+const RAPID_VIEWPORT_INTERVAL_MS = 48;
+const RAPID_SCROLL_SETTLE_MS = 96;
+const COARSE_HIGHLIGHT_LINE_BUDGET = 240;
+const MAX_DECORATIONS_PER_CHUNK = 2500;
+
+function normalizeVisibleRanges(
+	ranges: readonly { from: number; to: number }[],
+): { from: number; to: number }[] {
+	const sorted = ranges
+		.filter((r) => r.to > r.from)
+		.map((r) => ({ from: r.from, to: r.to }))
+		.sort((a, b) => a.from - b.from || a.to - b.to);
+	const merged: { from: number; to: number }[] = [];
+	for (const range of sorted) {
+		const last = merged[merged.length - 1];
+		if (!last || range.from > last.to) merged.push(range);
+		else if (range.to > last.to) last.to = range.to;
+	}
+	return merged;
+}
+
+function isSameRanges(
+	a: { from: number; to: number }[],
+	b: { from: number; to: number }[],
+) {
+	if (a.length !== b.length) return false;
+	for (let i = 0; i < a.length; i++) {
+		if (a[i]?.from !== b[i]?.from || a[i]?.to !== b[i]?.to) return false;
+	}
+	return true;
+}
+
+function sortDecorationEntries(entries: DecorationEntry[]): DecorationEntry[] {
+	return entries
+		.filter((e) => e.to > e.from)
+		.sort((a, b) => a.from - b.from || a.to - b.to);
+}
+
+function buildDecorationsFromEntries(
+	entries: DecorationEntry[],
+	alreadySorted = false,
+): DecorationSet {
+	const builder = new RangeSetBuilder<Decoration>();
+	const sorted = alreadySorted
+		? entries.filter((e) => e.to > e.from)
+		: sortDecorationEntries(entries);
+	let warned = false;
+	for (const entry of sorted) {
+		try {
+			builder.add(entry.from, entry.to, entry.mark);
+		} catch (err) {
+			if (!warned) {
+				console.warn("[shiki-editor] skip invalid decoration range:", err);
+				warned = true;
+			}
+		}
+	}
+	return builder.finish();
+}
+
+function shouldDeferViewportHighlight(
+	now: number,
+	lastViewportChangeAt: number,
+	rapidIntervalMs = RAPID_VIEWPORT_INTERVAL_MS,
+): boolean {
+	return (
+		lastViewportChangeAt > 0 && now - lastViewportChangeAt < rapidIntervalMs
+	);
+}
+
+function trimRangesByLineBudget(
+	doc: Text,
+	ranges: { from: number; to: number }[],
+	lineBudget = COARSE_HIGHLIGHT_LINE_BUDGET,
+): { from: number; to: number }[] {
+	if (lineBudget <= 0 || ranges.length === 0) return [];
+	let remaining = lineBudget;
+	const trimmed: { from: number; to: number }[] = [];
+	for (const range of ranges) {
+		if (remaining <= 0) break;
+		const startLine = doc.lineAt(range.from).number;
+		const endLine = doc.lineAt(range.to).number;
+		const lineCount = endLine - startLine + 1;
+		if (lineCount <= remaining) {
+			trimmed.push(range);
+			remaining -= lineCount;
+			continue;
+		}
+		const capLineNumber = Math.max(startLine, startLine + remaining - 1);
+		const capLine = doc.line(capLineNumber);
+		const capTo = Math.min(range.to, capLine.to);
+		if (capTo > range.from) trimmed.push({ from: range.from, to: capTo });
+		remaining = 0;
+	}
+	if (trimmed.length === 0 && ranges[0]) {
+		const firstLine = doc.lineAt(ranges[0].from);
+		return [
+			{
+				from: ranges[0].from,
+				to: Math.min(ranges[0].to, firstLine.to),
+			},
+		];
+	}
+	return trimmed;
+}
+
+const requestIdleCallback =
+	typeof globalThis !== "undefined" && globalThis.requestIdleCallback
+		? globalThis.requestIdleCallback.bind(globalThis)
+		: (cb: () => void) => setTimeout(cb, 1);
+
+const cancelIdleCallback =
+	typeof globalThis !== "undefined" && globalThis.cancelIdleCallback
+		? globalThis.cancelIdleCallback.bind(globalThis)
+		: clearTimeout;
+
+class ShikiView {
+	decorations: DecorationSet = RangeSet.empty;
+	lastPos = { from: 0, to: 0 };
+	private pendingHighlight: ReturnType<typeof requestIdleCallback> | null =
+		null;
+	private pendingViewportSettle: ReturnType<typeof setTimeout> | null = null;
+	private highlightRequestId = 0;
+	private lastViewportChangeAt = 0;
+
+	constructor(
+		public shikiHighlighter: ShikiHighlighter,
+		view: EditorView,
+	) {
+		this.updateHighlight(view);
+	}
+
+	destroy() {
+		this.cancelPendingHighlight();
+		this.cancelPendingViewportSettle();
+		this.decorations = RangeSet.empty;
+	}
+
+	update(update: ViewUpdate) {
+		let hasUpdateEffect = false;
+		for (const tr of update.transactions) {
+			for (const effect of tr.effects) {
+				if (effect.is(updateEffect)) {
+					hasUpdateEffect = true;
+					const patch = effect.value as Partial<Options>;
+					void this.shikiHighlighter
+						.update(patch, update.view)
+						.then(() => this.updateHighlight(update.view));
+				}
+			}
+		}
+		if (update.docChanged) {
+			this.decorations = this.decorations.map(update.changes);
+			if (!hasUpdateEffect) this.docChangeHighlight(update);
+		} else if (update.viewportChanged) {
+			this.handleViewportChanged(update.view);
+		} else if (update.transactions.some((tr) => tr.reconfigured)) {
+			this.updateHighlight(update.view);
+		}
+	}
+
+	private cancelPendingHighlight() {
+		if (this.pendingHighlight !== null) {
+			cancelIdleCallback(this.pendingHighlight as number);
+			this.pendingHighlight = null;
+		}
+	}
+
+	private cancelPendingViewportSettle() {
+		if (this.pendingViewportSettle !== null) {
+			clearTimeout(this.pendingViewportSettle);
+			this.pendingViewportSettle = null;
+		}
+	}
+
+	private handleViewportChanged(view: EditorView) {
+		const now = Date.now();
+		const shouldDefer = shouldDeferViewportHighlight(
+			now,
+			this.lastViewportChangeAt,
+		);
+		this.lastViewportChangeAt = now;
+		if (!shouldDefer) {
+			this.cancelPendingViewportSettle();
+			this.updateHighlight(view, { coarse: false });
+			return;
+		}
+		this.cancelPendingViewportSettle();
+		this.updateHighlight(view, { coarse: true });
+		this.pendingViewportSettle = setTimeout(() => {
+			this.pendingViewportSettle = null;
+			this.updateHighlight(view, { coarse: false });
+		}, RAPID_SCROLL_SETTLE_MS);
+	}
+
+	docChangeHighlight(update: ViewUpdate) {
+		this.cancelPendingHighlight();
+		this.cancelPendingViewportSettle();
+		const requestId = ++this.highlightRequestId;
+		const doc = update.view.state.doc;
+		const ranges = normalizeVisibleRanges(update.view.visibleRanges);
+		if (doc.length === 0 || ranges.length === 0) {
+			this.decorations = RangeSet.empty;
+			return;
+		}
+		const entries: DecorationEntry[] = [];
+		for (const { from, to } of ranges) {
+			this.shikiHighlighter.highlight(doc, from, to, (f, t, mark) => {
+				entries.push({ from: f, to: t, mark });
+			});
+			this.lastPos = { from, to };
+		}
+		if (requestId !== this.highlightRequestId) return;
+		this.decorations = buildDecorationsFromEntries(entries);
+	}
+
+	updateHighlight(
+		view: EditorView,
+		options: { coarse?: boolean; chunked?: boolean } = {},
+	) {
+		this.cancelPendingHighlight();
+		const doc = view.state.doc;
+		const normalizedVisibleRanges = normalizeVisibleRanges(view.visibleRanges);
+		const newVisibleRanges = options.coarse
+			? trimRangesByLineBudget(doc, normalizedVisibleRanges)
+			: normalizedVisibleRanges;
+		const useChunked = options.chunked !== false;
+		const requestId = ++this.highlightRequestId;
+		if (doc.length === 0 || newVisibleRanges.length === 0) {
+			this.decorations = RangeSet.empty;
+			return;
+		}
+		const requestedRanges = newVisibleRanges.map((r) => ({ ...r }));
+		const pendingRanges = newVisibleRanges.slice();
+		const entries: DecorationEntry[] = [];
+		const runChunk = () => {
+			if (requestId !== this.highlightRequestId) {
+				this.pendingHighlight = null;
+				return;
+			}
+			const currentRanges = normalizeVisibleRanges(view.visibleRanges);
+			if (!isSameRanges(requestedRanges, currentRanges)) {
+				this.pendingHighlight = null;
+				return;
+			}
+			let remainingDecorations = useChunked
+				? MAX_DECORATIONS_PER_CHUNK
+				: Number.MAX_SAFE_INTEGER;
+			try {
+				while (pendingRanges.length > 0 && remainingDecorations > 0) {
+					const current = pendingRanges.shift();
+					if (current === undefined) break;
+					const result = this.shikiHighlighter.highlight(
+						doc,
+						current.from,
+						current.to,
+						(f, t, mark) => {
+							if (remainingDecorations <= 0) return;
+							remainingDecorations--;
+							entries.push({ from: f, to: t, mark });
+						},
+						{ maxDecorations: remainingDecorations },
+					);
+					if (result.nextFrom !== null && result.nextFrom < current.to) {
+						pendingRanges.unshift({ from: result.nextFrom, to: current.to });
+					}
+					this.lastPos = { from: current.from, to: current.to };
+				}
+			} catch (error) {
+				console.error("[shiki-editor] highlight failed:", error);
+			}
+			const snapshot = entries.slice();
+			if (requestId !== this.highlightRequestId) return;
+			this.decorations = buildDecorationsFromEntries(snapshot);
+			this.pendingHighlight = null;
+			view.dispatch({});
+			if (
+				useChunked &&
+				pendingRanges.length > 0 &&
+				requestId === this.highlightRequestId
+			) {
+				this.pendingHighlight = requestIdleCallback(runChunk);
+			}
+		};
+		this.pendingHighlight = requestIdleCallback(runChunk);
+	}
+}
+
+function shikiViewPlugin(
+	shikiHighlighter: ShikiHighlighter,
+	_options: ShikiToCMOptions,
+) {
+	return {
+		viewPlugin: ViewPlugin.define(
+			(view: EditorView) => new ShikiView(shikiHighlighter.setView(view), view),
+			{ decorations: (v) => v.decorations },
+		),
+	};
+}
+
+async function shikiPlugin(
+	highlighter: Highlighter,
+	ctOptions: ShikiToCMOptions,
+	initShikiFn?: InitShikiFn,
+) {
+	const shikiHighlighter = new ShikiHighlighter(
+		highlighter,
+		ctOptions,
+		initShikiFn,
+	);
+	const { viewPlugin } = shikiViewPlugin(shikiHighlighter, ctOptions);
+	const initialTheme = shikiHighlighter.initTheme();
+	return {
+		getTheme(name?: string, view?: EditorView) {
+			if (view) shikiHighlighter.setView(view);
+			return shikiHighlighter.getTheme(name);
+		},
+		shiki: [themeCompartment.of(initialTheme), viewPlugin],
+	};
+}
+
+async function createShikiToCodeMirror(
+	shikiOptions: Options,
+	initShikiFn: InitShikiFn,
+) {
+	const normalizedOptions = { ...shikiOptions };
+	const { theme, themes } = normalizedOptions as {
+		theme?: string;
+		themes?: ThemeRegistry;
+	};
+	if (!themes) {
+		if (theme) {
+			(normalizedOptions as { themes: ThemeRegistry }).themes = {
+				light: theme,
+			};
+		} else {
+			throw new Error(
+				"[shiki-editor] Invalid options: provide `theme` or `themes`.",
+			);
+		}
+	}
+	if (themes && theme) {
+		delete (normalizedOptions as { theme?: string }).theme;
+	}
+	const options = {
+		...defaultShikiOptions,
+		...normalizedOptions,
+	} as ShikiToCMOptions;
+	if (options.warnings) {
+		if (theme && themes) {
+			console.warn(
+				"[shiki-editor] Both `theme` and `themes` provided; using `themes`.",
+			);
+		}
+		if (
+			typeof options.defaultColor === "string" &&
+			options.themes &&
+			!(options.defaultColor in options.themes)
+		) {
+			console.warn(
+				`[shiki-editor] defaultColor "${options.defaultColor}" is not a key in themes.`,
+			);
+		}
+	}
+	const core = await initShikiFn(options);
+	return shikiPlugin(core, options, initShikiFn);
+}
+
+function normalizeLangForShiki(lang: unknown): unknown {
+	if (lang === "text") return "log";
+	return lang;
+}
+
+function partitionOptions<TThemes extends ThemeRegistry>(
+	options: ShikiEditorOptions<TThemes>,
+) {
+	const shikiKeys = [
+		"lang",
+		"langAlias",
+		"theme",
+		"themes",
+		"themeStyle",
+		"includeExplanation",
+		"cssVariablePrefix",
+		"colorReplacements",
+		"warnings",
+		"tokenizeMaxLineLength",
+		"tokenizeTimeLimit",
+		"defaultColor",
+		"highlighter",
+		"versionGuard",
+		"resolveLang",
+		"resolveTheme",
+	] as const;
+	const cmKeys = [
+		"extensions",
+		"parent",
+		"state",
+		"selection",
+		"dispatch",
+		"dispatchTransactions",
+		"root",
+		"scrollTo",
+		"doc",
+	] as const;
+	function pick(keys: readonly string[]) {
+		const o = options as unknown as Record<string, unknown>;
+		return Object.fromEntries(
+			Object.entries(o).filter(([k]) => keys.includes(k)),
+		);
+	}
+	const rawShiki = pick(shikiKeys) as Options<TThemes>;
+	rawShiki.lang = normalizeLangForShiki(rawShiki.lang);
+	return {
+		shikiOptions: rawShiki,
+		cmOptions: pick(cmKeys) as Omit<
+			ShikiEditorOptions<TThemes>,
+			(typeof shikiKeys)[number] | "onUpdate"
+		>,
+	};
+}
+
+async function initPlaygroundHighlighter(
+	options: Omit<ShikiToCMOptions, "theme">,
+): Promise<Highlighter> {
+	const themeNames = Object.values(options.themes)
+		.map((t) =>
+			typeof t === "string" ? t : String((t as { name?: string }).name),
+		)
+		.filter(Boolean) as string[];
+	const highlighter = await createHighlighter({
+		themes: themeNames,
+		langs: ["ballerina", "toml", "log"],
+	});
+	assertCompatibleHighlighter(
+		highlighter,
+		"[shiki-editor]",
+		options.warnings,
+		options.versionGuard !== false,
+	);
+	return highlighter;
+}
+
+const shikiComp = new Compartment();
+
+export class ShikiEditor<TThemes extends ThemeRegistry = ThemeRegistry> {
+	view: EditorView;
+	getTheme: Promise<(name?: string, view?: EditorView) => Extension>;
+
+	constructor(options: ShikiEditorOptions<TThemes>) {
+		const { shikiOptions, cmOptions } = partitionOptions(options);
+		const userExtensions = cmOptions.extensions;
+		const baseExtensions: Extension[] = [
+			...(options.onUpdate
+				? [EditorView.updateListener.of(options.onUpdate)]
+				: []),
+		];
+		const cmExt = Array.isArray(userExtensions)
+			? [...userExtensions, ...baseExtensions]
+			: userExtensions
+				? [userExtensions, ...baseExtensions]
+				: baseExtensions;
+
+		this.view = new EditorView({
+			...cmOptions,
+			extensions: [...cmExt, shikiComp.of([])],
+		});
+
+		this.getTheme = createShikiToCodeMirror(
+			shikiOptions as Options<TThemes>,
+			initPlaygroundHighlighter,
+		).then(({ getTheme, shiki }) => {
+			this.view.dispatch({
+				effects: shikiComp.reconfigure(shiki),
+			});
+			return getTheme;
+		});
+	}
+
+	update(partial: Partial<Pick<Options<TThemes>, "lang">>) {
+		const mapped =
+			partial.lang !== undefined
+				? { ...partial, lang: normalizeLangForShiki(partial.lang) }
+				: partial;
+		this.view.dispatch({ effects: updateEffect.of(mapped) });
+	}
+
+	getValue(): string {
+		return this.view.state.doc.toString();
+	}
+
+	setValue(doc: string) {
+		this.view.dispatch({
+			changes: { from: 0, to: this.view.state.doc.length, insert: doc },
+		});
+	}
+
+	destroy() {
+		this.view.destroy();
+	}
+}

--- a/apps/web/src/components/shiki-editor.ts
+++ b/apps/web/src/components/shiki-editor.ts
@@ -1213,6 +1213,15 @@ export class ShikiEditor<TThemes extends ThemeRegistry = ThemeRegistry> {
 		});
 	}
 
+	reconfigure(
+		compartment: Compartment,
+		extension: Extension | readonly Extension[],
+	) {
+		this.view.dispatch({
+			effects: compartment.reconfigure(extension),
+		});
+	}
+
 	destroy() {
 		this.view.destroy();
 	}

--- a/apps/web/src/stores/editor-store.ts
+++ b/apps/web/src/stores/editor-store.ts
@@ -30,14 +30,14 @@ export type EditorActions = {
 
 export type EditorStore = EditorState & EditorActions;
 
-const initial: EditorState = {
+const initial = {
 	output: "",
 	outputOpen: false,
-	editorMode: readStoredEditorMode(),
-};
+} satisfies Omit<EditorState, "editorMode">;
 
 export const useEditorStore = create<EditorStore>((set, get) => ({
 	...initial,
+	editorMode: readStoredEditorMode(),
 
 	setOutput: (output) => set({ output }),
 	clearOutput: () => set({ output: initial.output }),
@@ -59,5 +59,5 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
 			}
 			return { editorMode };
 		}),
-	reset: () => set(initial),
+	reset: () => set({ ...initial, editorMode: readStoredEditorMode() }),
 }));

--- a/apps/web/src/stores/editor-store.ts
+++ b/apps/web/src/stores/editor-store.ts
@@ -1,8 +1,20 @@
 import { create } from "zustand";
 
+const EDITOR_MODE_STORAGE_KEY = "playground.editor.mode";
+
+type EditorMode = "standard" | "vim";
+
+function readStoredEditorMode(): EditorMode {
+	if (typeof localStorage === "undefined") return "standard";
+	return localStorage.getItem(EDITOR_MODE_STORAGE_KEY) === "vim"
+		? "vim"
+		: "standard";
+}
+
 export type EditorState = {
 	output: string;
 	outputOpen: boolean;
+	editorMode: EditorMode;
 };
 
 export type EditorActions = {
@@ -11,6 +23,8 @@ export type EditorActions = {
 	openOutputWith: (output: string) => void;
 	setOutputOpen: (outputOpen: boolean) => void;
 	toggleOutputOpen: () => void;
+	setEditorMode: (mode: EditorMode) => void;
+	toggleEditorMode: () => void;
 	reset: () => void;
 };
 
@@ -19,6 +33,7 @@ export type EditorStore = EditorState & EditorActions;
 const initial: EditorState = {
 	output: "",
 	outputOpen: false,
+	editorMode: readStoredEditorMode(),
 };
 
 export const useEditorStore = create<EditorStore>((set, get) => ({
@@ -29,5 +44,20 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
 	openOutputWith: (output) => set({ output, outputOpen: true }),
 	setOutputOpen: (outputOpen) => set({ outputOpen }),
 	toggleOutputOpen: () => set({ outputOpen: !get().outputOpen }),
+	setEditorMode: (editorMode) => {
+		if (typeof localStorage !== "undefined") {
+			localStorage.setItem(EDITOR_MODE_STORAGE_KEY, editorMode);
+		}
+		set({ editorMode });
+	},
+	toggleEditorMode: () =>
+		set((s) => {
+			const editorMode: EditorMode =
+				s.editorMode === "vim" ? "standard" : "vim";
+			if (typeof localStorage !== "undefined") {
+				localStorage.setItem(EDITOR_MODE_STORAGE_KEY, editorMode);
+			}
+			return { editorMode };
+		}),
 	reset: () => set(initial),
 }));

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@hugeicons/core-free-icons": "^4.1.1",
         "@hugeicons/react": "^1.1.6",
+        "@replit/codemirror-vim": "^6.3.0",
         "@tailwindcss/vite": "^4.2.1",
         "@tanstack/react-router": "^1.168.10",
         "class-variance-authority": "^0.7.1",
@@ -289,7 +290,9 @@
 
     "@playground/web": ["@playground/web@workspace:apps/web"],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.13", "", { "os": "android", "cpu": "arm64" }, "sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g=="],
+    "@replit/codemirror-vim": ["@replit/codemirror-vim@6.3.0", "", { "peerDependencies": { "@codemirror/commands": "6.x.x", "@codemirror/language": "6.x.x", "@codemirror/search": "6.x.x", "@codemirror/state": "6.x.x", "@codemirror/view": "6.x.x" } }, "sha512-aTx931ULAMuJx6xLf7KQDOL7CxD+Sa05FktTDrtLaSy53uj01ll3Zf17JdKsriER248oS55GBzg0CfCTjEneAQ=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.12", "", { "os": "android", "cpu": "arm64" }, "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA=="],
 
     "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.13", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA=="],
 
@@ -1059,7 +1062,7 @@
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
-    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,13 +6,20 @@
       "name": "@playground/monorepo",
       "devDependencies": {
         "@biomejs/biome": "^2.4.10",
-        "turbo": "^2.9.4",
+        "turbo": "^2.9.5",
       },
     },
     "apps/web": {
       "name": "@playground/web",
       "dependencies": {
         "@base-ui/react": "^1.3.0",
+        "@codemirror/autocomplete": "^6.20.1",
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/language": "^6.12.3",
+        "@codemirror/legacy-modes": "^6.5.2",
+        "@codemirror/search": "^6.6.0",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/view": "^6.41.0",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@hugeicons/core-free-icons": "^4.1.1",
         "@hugeicons/react": "^1.1.6",
@@ -20,11 +27,12 @@
         "@tanstack/react-router": "^1.168.10",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "codemirror": "^6.0.2",
         "immer": "^11.1.4",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-hotkeys-hook": "^5.2.4",
-        "shadcn": "^4.1.2",
+        "shadcn": "^4.2.0",
         "shiki": "^4.0.2",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
@@ -39,8 +47,9 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "globals": "^17.4.0",
+        "style-mod": "^4.1.3",
         "typescript": "~6.0.2",
-        "vite": "^8.0.4",
+        "vite": "^8.0.7",
       },
     },
     "packages/wasm": {
@@ -127,6 +136,22 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-umwQU6qPzH+ISTf/eHyJ/QoQnJs3V9Vpjz2OjZXe9MVBZ7prgGafMy7yYeRGnlmDAn87AKTF3Q6weLoMGpeqdQ=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.10", "", { "os": "win32", "cpu": "x64" }, "sha512-aW/JU5GuyH4uxMrNYpoC2kjaHlyJGLgIa3XkhPEZI0uKhZhJZU8BuEyJmvgzSPQNGozBwWjC972RaNdcJ9KyJg=="],
+
+    "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.1", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A=="],
+
+    "@codemirror/commands": ["@codemirror/commands@6.10.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.6.0", "@codemirror/view": "^6.27.0", "@lezer/common": "^1.1.0" } }, "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q=="],
+
+    "@codemirror/language": ["@codemirror/language@6.12.3", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA=="],
+
+    "@codemirror/legacy-modes": ["@codemirror/legacy-modes@6.5.2", "", { "dependencies": { "@codemirror/language": "^6.0.0" } }, "sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q=="],
+
+    "@codemirror/lint": ["@codemirror/lint@6.9.5", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.35.0", "crelt": "^1.0.5" } }, "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA=="],
+
+    "@codemirror/search": ["@codemirror/search@6.6.0", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.37.0", "crelt": "^1.0.5" } }, "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw=="],
+
+    "@codemirror/state": ["@codemirror/state@6.6.0", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ=="],
+
+    "@codemirror/view": ["@codemirror/view@6.41.0", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA=="],
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.58.0", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-xizSguxyyvH5eqGWJrhTomUdXFSRaweXBEXxTpkbaalIjHZeKPNPHpevwxCXXqdXPe5bTIeEtBSKD+zStadGFw=="],
 
@@ -226,11 +251,19 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@lezer/common": ["@lezer/common@1.5.1", "", {}, "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw=="],
+
+    "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
+
+    "@lezer/lr": ["@lezer/lr@1.4.8", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA=="],
+
+    "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
+
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.28.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw=="],
 
     "@mswjs/interceptors": ["@mswjs/interceptors@0.41.3", "", { "dependencies": { "@open-draft/deferred-promise": "^2.2.0", "@open-draft/logger": "^0.3.0", "@open-draft/until": "^2.0.0", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "strict-event-emitter": "^0.5.1" } }, "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA=="],
 
-    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" } }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.2", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw=="],
 
     "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
@@ -250,41 +283,41 @@
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.122.0", "", {}, "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA=="],
+    "@oxc-project/types": ["@oxc-project/types@0.123.0", "", {}, "sha512-YtECP/y8Mj1lSHiUWGSRzy/C6teUKlS87dEfuVKT09LgQbUsBW1rNg+MiJ4buGu3yuADV60gbIvo9/HplA56Ew=="],
 
     "@playground/wasm": ["@playground/wasm@workspace:packages/wasm"],
 
     "@playground/web": ["@playground/web@workspace:apps/web"],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.12", "", { "os": "android", "cpu": "arm64" }, "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.13", "", { "os": "android", "cpu": "arm64" }, "sha512-5ZiiecKH2DXAVJTNN13gNMUcCDg4Jy8ZjbXEsPnqa248wgOVeYRX0iqXXD5Jz4bI9BFHgKsI2qmyJynstbmr+g=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.0.0-rc.13", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tz/v/8G77seu8zAB3A5sK3UFoOl06zcshEzhUO62sAEtrEuW/H1CcyoupOrD+NbQJytYgA4CppXPzlrmp4JZKA=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.0.0-rc.13", "", { "os": "darwin", "cpu": "x64" }, "sha512-8DakphqOz8JrMYWTJmWA+vDJxut6LijZ8Xcdc4flOlAhU7PNVwo2MaWBF9iXjJAPo5rC/IxEFZDhJ3GC7NHvug=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.0.0-rc.13", "", { "os": "freebsd", "cpu": "x64" }, "sha512-4wBQFfjDuXYN/SVI8inBF3Aa+isq40rc6VMFbk5jcpolUBTe5cYnMsHZ51nFWsx3PVyyNN3vgoESki0Hmr/4BA=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12", "", { "os": "linux", "cpu": "arm" }, "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.13", "", { "os": "linux", "cpu": "arm" }, "sha512-JW/e4yPIXLms+jmnbwwy5LA/LxVwZUWLN8xug+V200wzaVi5TEGIWQlh8o91gWYFxW609euI98OCCemmWGuPrw=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.0.0-rc.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZfKWpXiUymDnavepCaM6KG/uGydJ4l2nBmMxg60Ci4CbeefpqjPWpfaZM7PThOhk2dssqBAcwLc6rAyr0uTdXg=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.0.0-rc.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-bmRg3O6Z0gq9yodKKWCIpnlH051sEfdVwt+6m5UDffAQMUUqU0xjnQqqAUm+Gu7ofAAly9DqiQDtKu2nPDEABA=="],
 
-    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g=="],
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.13", "", { "os": "linux", "cpu": "ppc64" }, "sha512-8Wtnbw4k7pMYN9B/mOEAsQ8HOiq7AZ31Ig4M9BKn2So4xRaFEhtCSa4ZJaOutOWq50zpgR4N5+L/opnlaCx8wQ=="],
 
-    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og=="],
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.0.0-rc.13", "", { "os": "linux", "cpu": "s390x" }, "sha512-D/0Nlo8mQuxSMohNJUF2lDXWRsFDsHldfRRgD9bRgktj+EndGPj4DOV37LqDKPYS+osdyhZEH7fTakTAEcW7qg=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.12", "", { "os": "linux", "cpu": "x64" }, "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.0.0-rc.13", "", { "os": "linux", "cpu": "x64" }, "sha512-eRrPvat2YaVQcwwKi/JzOP6MKf1WRnOCr+VaI3cTWz3ZoLcP/654z90lVCJ4dAuMEpPdke0n+qyAqXDZdIC4rA=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.12", "", { "os": "linux", "cpu": "x64" }, "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.0.0-rc.13", "", { "os": "linux", "cpu": "x64" }, "sha512-PsdONiFRp8hR8KgVjTWjZ9s7uA3uueWL0t74/cKHfM4dR5zXYv4AjB8BvA+QDToqxAFg4ZkcVEqeu5F7inoz5w=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.12", "", { "os": "none", "cpu": "arm64" }, "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.0.0-rc.13", "", { "os": "none", "cpu": "arm64" }, "sha512-hCNXgC5dI3TVOLrPT++PKFNZ+1EtS0mLQwfXXXSUD/+rGlB65gZDwN/IDuxLpQP4x8RYYHqGomlUXzpO8aVI2w=="],
 
-    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.12", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.1" }, "cpu": "none" }, "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg=="],
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.0.0-rc.13", "", { "dependencies": { "@emnapi/core": "1.9.1", "@emnapi/runtime": "1.9.1", "@napi-rs/wasm-runtime": "^1.1.2" }, "cpu": "none" }, "sha512-viLS5C5et8NFtLWw9Sw3M/w4vvnVkbWkO7wSNh3C+7G1+uCkGpr6PcjNDSFcNtmXY/4trjPBqUfcOL+P3sWy/g=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.0.0-rc.13", "", { "os": "win32", "cpu": "arm64" }, "sha512-Fqa3Tlt1xL4wzmAYxGNFV36Hb+VfPc9PYU+E25DAnswXv3ODDu/yyWjQDbXMo5AGWkQVjLgQExuVu8I/UaZhPQ=="],
 
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.12", "", { "os": "win32", "cpu": "x64" }, "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.0.0-rc.13", "", { "os": "win32", "cpu": "x64" }, "sha512-/pLI5kPkGEi44TDlnbio3St/5gUFeN51YWNAk/Gnv6mEQBOahRBh52qVFVBpmrnU01n2yysvBML9Ynu7K4kGAQ=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
@@ -358,17 +391,17 @@
 
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 
-    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZSlPqJ5Vqg/wgVw8P3AOVCIosnbBilOxLq7TMz3MN/9U46DUYfdG2jtfevNDufyxyrg98pcPs/GBgDRaaids6g=="],
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-qPxhKsLMQP+9+dsmPgAGidi5uNifD4AoAOnEnljab3Qgn0QZRR31Hp+/CgW3Ia5AanWj6JuLLTBYvuQj4mqTWg=="],
 
-    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9cjTWe4OiNlFMSRggPNh+TJlRs7MS5FWrHc96MOzft5vESWjjpvaadYPv5ykDW7b45mVHOF2U/W+48LoX9USWw=="],
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vkF/9F/l3aWd4bHxTui5Hh0F5xrTZ4e3rbBsc57zA6O8gNbmHN3B6eZ5psAIP2CnJRZ8ZxRjV3WZHeNXMXkPBw=="],
 
-    "@turbo/linux-64": ["@turbo/linux-64@2.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-Cl1GjxqBXQ+r9KKowmXG+lhD1gclLp48/SE7NxL//66iaMytRw0uiphWGOkccD92iPiRjHLRUaA9lOTtgr5OCA=="],
+    "@turbo/linux-64": ["@turbo/linux-64@2.9.5", "", { "os": "linux", "cpu": "x64" }, "sha512-z/Get5NUaUxm5HSGFqVMICDRjFNsCUhSc4wnFa/PP1QD0NXCjr7bu9a2EM6md/KMCBW0Qe393Ac+UM7/ryDDTw=="],
 
-    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-j2hPAKVmGNN2EsKigEWD+43y9m7zaPhNAs6ptsyfq0u7evHHBAXAwOfv86OEMg/gvC+pwGip0i1CIm1bR1vYug=="],
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-jyBifaNoI5/NheyswomiZXJvjdAdvT7hDRYzQ4meP0DKGvpXUjnqsD+4/J2YSDQ34OHxFkL30FnSCUIVOh2PHw=="],
 
-    "@turbo/windows-64": ["@turbo/windows-64@2.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-1jWPjCe9ZRmsDTXE7uzqfySNQspnUx0g6caqvwps+k/sc+fm9hC/4zRQKlXZLbVmP3Xxp601Ju71boegHdnYGw=="],
+    "@turbo/windows-64": ["@turbo/windows-64@2.9.5", "", { "os": "win32", "cpu": "x64" }, "sha512-ph24K5uPtvo7UfuyDXnBiB/8XvrO+RQWbbw5zkA/bVNoy9HDiNoIJJj3s62MxT9tjEb6DnPje5PXSz1UR7QAyg=="],
 
-    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-dlko15TQVu/BFYmIY018Y3covWMRQlUgAkD+OOk+Rokcfj6VY02Vv4mCfT/Zns6B4q8jGbOd6IZhnCFYsE8Viw=="],
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-6c5RccT/+iR39SdT1G5HyZaD2n57W77o+l0TTfxG/cVlhV94Acyg2gTQW7zUOhW1BeQpBjHzu9x8yVBZwrHh7g=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
@@ -466,6 +499,8 @@
 
     "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
 
+    "codemirror": ["codemirror@6.0.2", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/commands": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/lint": "^6.0.0", "@codemirror/search": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
@@ -489,6 +524,8 @@
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cosmiconfig": ["cosmiconfig@9.0.1", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ=="],
+
+    "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -908,7 +945,7 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
-    "rolldown": ["rolldown@1.0.0-rc.12", "", { "dependencies": { "@oxc-project/types": "=0.122.0", "@rolldown/pluginutils": "1.0.0-rc.12" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.12", "@rolldown/binding-darwin-arm64": "1.0.0-rc.12", "@rolldown/binding-darwin-x64": "1.0.0-rc.12", "@rolldown/binding-freebsd-x64": "1.0.0-rc.12", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A=="],
+    "rolldown": ["rolldown@1.0.0-rc.13", "", { "dependencies": { "@oxc-project/types": "=0.123.0", "@rolldown/pluginutils": "1.0.0-rc.13" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.13", "@rolldown/binding-darwin-arm64": "1.0.0-rc.13", "@rolldown/binding-darwin-x64": "1.0.0-rc.13", "@rolldown/binding-freebsd-x64": "1.0.0-rc.13", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.13", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.13", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.13", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.13", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.13", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.13", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.13", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.13", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.13", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.13", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.13" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-bvVj8YJmf0rq4pSFmH7laLa6pYrhghv3PRzrCdRAr23g66zOKVJ4wkvFtgohtPLWmthgg8/rkaqRHrpUEh0Zbw=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
@@ -932,7 +969,7 @@
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
-    "shadcn": ["shadcn@4.1.2", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/parser": "^7.28.0", "@babel/plugin-transform-typescript": "^7.28.0", "@babel/preset-typescript": "^7.27.1", "@dotenvx/dotenvx": "^1.48.4", "@modelcontextprotocol/sdk": "^1.26.0", "@types/validate-npm-package-name": "^4.0.2", "browserslist": "^4.26.2", "commander": "^14.0.0", "cosmiconfig": "^9.0.0", "dedent": "^1.6.0", "deepmerge": "^4.3.1", "diff": "^8.0.2", "execa": "^9.6.0", "fast-glob": "^3.3.3", "fs-extra": "^11.3.1", "fuzzysort": "^3.1.0", "https-proxy-agent": "^7.0.6", "kleur": "^4.1.5", "msw": "^2.10.4", "node-fetch": "^3.3.2", "open": "^11.0.0", "ora": "^8.2.0", "postcss": "^8.5.6", "postcss-selector-parser": "^7.1.0", "prompts": "^2.4.2", "recast": "^0.23.11", "stringify-object": "^5.0.0", "tailwind-merge": "^3.0.1", "ts-morph": "^26.0.0", "tsconfig-paths": "^4.2.0", "validate-npm-package-name": "^7.0.1", "zod": "^3.24.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "shadcn": "dist/index.js" } }, "sha512-qNQcCavkbYsgBj+X09tF2bTcwRd8abR880bsFkDU2kMqceMCLAm5c+cLg7kWDhfh1H9g08knpQ5ZEf6y/co16g=="],
+    "shadcn": ["shadcn@4.2.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/parser": "^7.28.0", "@babel/plugin-transform-typescript": "^7.28.0", "@babel/preset-typescript": "^7.27.1", "@dotenvx/dotenvx": "^1.48.4", "@modelcontextprotocol/sdk": "^1.26.0", "@types/validate-npm-package-name": "^4.0.2", "browserslist": "^4.26.2", "commander": "^14.0.0", "cosmiconfig": "^9.0.0", "dedent": "^1.6.0", "deepmerge": "^4.3.1", "diff": "^8.0.2", "execa": "^9.6.0", "fast-glob": "^3.3.3", "fs-extra": "^11.3.1", "fuzzysort": "^3.1.0", "https-proxy-agent": "^7.0.6", "kleur": "^4.1.5", "msw": "^2.10.4", "node-fetch": "^3.3.2", "open": "^11.0.0", "ora": "^8.2.0", "postcss": "^8.5.6", "postcss-selector-parser": "^7.1.0", "prompts": "^2.4.2", "recast": "^0.23.11", "stringify-object": "^5.0.0", "tailwind-merge": "^3.0.1", "ts-morph": "^26.0.0", "tsconfig-paths": "^4.2.0", "validate-npm-package-name": "^7.0.1", "zod": "^3.24.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "shadcn": "dist/index.js" } }, "sha512-ZDuV340itidaUd4Gi1BxQX+Y7Ush6BHp6URZBM2RyxUUBZ6yFtOWIr4nVY+Ro+YRSpo82v7JrsmtcU5xoBCMJQ=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -978,6 +1015,8 @@
 
     "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
 
+    "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
+
     "tabbable": ["tabbable@6.4.0", "", {}, "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="],
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
@@ -1012,7 +1051,7 @@
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
-    "turbo": ["turbo@2.9.4", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.4", "@turbo/darwin-arm64": "2.9.4", "@turbo/linux-64": "2.9.4", "@turbo/linux-arm64": "2.9.4", "@turbo/windows-64": "2.9.4", "@turbo/windows-arm64": "2.9.4" }, "bin": { "turbo": "bin/turbo" } }, "sha512-wZ/kMcZCuK5oEp7sXSSo/5fzKjP9I2EhoiarZjyCm2Ixk0WxFrC/h0gF3686eHHINoFQOOSWgB/pGfvkR8rkgQ=="],
+    "turbo": ["turbo@2.9.5", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.5", "@turbo/darwin-arm64": "2.9.5", "@turbo/linux-64": "2.9.5", "@turbo/linux-arm64": "2.9.5", "@turbo/windows-64": "2.9.5", "@turbo/windows-arm64": "2.9.5" }, "bin": { "turbo": "bin/turbo" } }, "sha512-JXNkRe6H6MjSlk5UQRTjyoKX5YN2zlc2632xcSlSFBao5yvbMWTpv9SNolOZlZmUlcDOHuszPLItbKrvcXnnZA=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
@@ -1058,7 +1097,9 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
-    "vite": ["vite@8.0.4", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-baBr4jUVSLJ0RPyZ2nK0zS2+W8hNHbM4hEzfvllukmRPVS3xDG5ATTNtbRXrKIOE2b8/FsPWJAOnuIxcs7g3cw=="],
+    "vite": ["vite@8.0.7", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.13", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-P1PbweD+2/udplnThz3btF4cf6AgPky7kk23RtHUkJIU5BIxwPprhRGmOAHs6FTI7UiGbTNrgNP6jSYD6JaRnw=="],
+
+    "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
@@ -1134,7 +1175,7 @@
 
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
-    "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.12", "", {}, "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw=="],
+    "rolldown/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.13", "", {}, "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA=="],
 
     "router/path-to-regexp": ["path-to-regexp@8.4.0", "", {}, "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg=="],
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
 	"packageManager": "bun@1.3.10",
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.10",
-		"turbo": "^2.9.4"
+		"turbo": "^2.9.5"
 	}
 }


### PR DESCRIPTION
## Purpose
Resolves #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Refactors the web app’s editor to use CodeMirror instead of the previous Shiki+textarea overlay. Introduces a Shiki-to-CodeMirror bridge that applies Shiki tokenization and theming inside a CodeMirror EditorView, consolidates editor rendering into a single container, and replaces custom overlay synchronization with CodeMirror-driven editing and extensions.

## Key changes

- Editor framework migration
  - Replaced the custom Shiki-highlighted textarea overlay with a CodeMirror-based editor component.
  - Added a new ShikiEditor bridge that integrates Shiki tokenization and theme conversion with CodeMirror, including a runtime-reconfigurable theme compartment.
  - Simplified markup to render the editor into one container element.

- Features and UX
  - Added toggleable Vim mode with a compartment-based toggle and registration of Vim ex-commands (e.g., write/w).
  - Persisted editor mode (standard/vim) in localStorage and added store actions to set/toggle the mode.
  - Introduced configurable hotkeys for the editor and wired common shortcuts (Mod-Enter, Mod-Alt-V, Mod-R).

- Types and API
  - Added EditorLanguage type ("ballerina" | "toml" | "text") and tightened language typings.
  - Extended CodeEditor props with a hotkeys map and exported the ShikiEditor class and its options (update, getValue, setValue, reconfigure, destroy).

- Dependencies and tooling
  - Added CodeMirror packages and a Vim keybinding package to runtime dependencies.
  - Updated several dev dependencies (vite, style-mod, turbo) and bumped a shadcn version.

- Bug fixes
  - Fixed a stale-closure bug related to the Vim write command.

## Intent / Outcome

Improve maintainability and extensibility of the in-browser editor by centralizing highlighting and editor behavior in CodeMirror, enabling richer keybindings and modes, simplifying the rendering model, and persisting the user’s editor-mode preference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->