### PR TITLE
Remove delayed GET request from HTTP client example

### DIFF
--- a/examples/02-http-client.bal
+++ b/examples/02-http-client.bal
@@ -14,7 +14,4 @@ public function main() returns error? {
     res = check apiClient->post("/post", data);
     io:println("POST Response JSON Payload: ", check res.getJsonPayload());
     io:println("Post Response Content-Type Header: ", check res.getHeader("Content-Type"));
-
-    res = check apiClient->execute("GET", "/delay/5", {"X-Custom-Header": "BallerinaTimeout"});
-    io:println("Delayed Response Status: ", res.statusCode);
 }


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

This pull request simplifies the HTTP client example by removing the delayed GET request functionality from the `examples/02-http-client.bal` file. The `main` function previously included an additional HTTP request to a delay endpoint (`/delay/5`) that has now been removed, along with its associated response handling code. This streamlines the example to focus on the core HTTP client operations without the secondary delayed request demonstration.

**Lines changed:** 3 removed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/playground/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->