### PR TITLE
Add E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,9 @@ jobs:
       - name: Build web app
         run: bun run build
 
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps
+
+      - name: Run E2E tests
+        run: bun run test:e2e
+

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,7 @@ node_modules
 apps/*/dist
 packages/*/dist
 
+test-results/
+playwright-report/
+
 .DS_Store

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -445,7 +445,14 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
 						</SidebarGroupLabel>
 						<DropdownMenu>
 							<DropdownMenuTrigger
-								render={<Button variant="ghost" size="icon-xs" />}
+								render={
+									<Button
+										variant="ghost"
+										size="icon-xs"
+										aria-label="Add to localspace"
+										data-testid="localspace-add"
+									/>
+								}
 							>
 								<HugeiconsIcon icon={PlusSignIcon} strokeWidth={1.5} />
 							</DropdownMenuTrigger>

--- a/apps/web/src/components/editor.tsx
+++ b/apps/web/src/components/editor.tsx
@@ -237,6 +237,7 @@ function OutputPane() {
 			</div>
 			<div
 				ref={scrollRef}
+				data-testid="output-pane"
 				onScroll={updateAutoScrollState}
 				className={cn(
 					"min-h-0 overflow-y-auto p-4",
@@ -287,6 +288,7 @@ function EditorPane({
 				<Button
 					className="h-full rounded-none"
 					variant="ghost"
+					data-testid="run-button"
 					onClick={() => void onRun()}
 					disabled={
 						isRunning ||
@@ -403,7 +405,10 @@ function EditorContent() {
 function WasmLoadingScreen({ progress }: { progress: number }) {
 	const pct = Math.max(0, Math.min(100, progress));
 	return (
-		<div className="w-full flex items-center justify-center min-h-dvh">
+		<div
+			className="w-full flex items-center justify-center min-h-dvh"
+			data-testid="wasm-loading"
+		>
 			<div className="flex flex-col items-center gap-4">
 				<div className="text-sm text-muted-foreground">
 					Loading WASM binaries...&nbsp;

--- a/apps/web/src/components/file-tree-dialog.tsx
+++ b/apps/web/src/components/file-tree-dialog.tsx
@@ -292,7 +292,7 @@ export function FileTreeDialog() {
 
 	return (
 		<Dialog open={isOpen} onOpenChange={handleOpenChange}>
-			<DialogContent>
+			<DialogContent data-testid="file-tree-dialog">
 				<form onSubmit={handleSubmit} className="flex flex-col gap-4">
 					<DialogHeader>
 						<DialogTitle>{title}</DialogTitle>

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,8 @@
       "name": "@playground/monorepo",
       "devDependencies": {
         "@biomejs/biome": "^2.4.12",
+        "@playwright/test": "^1.60.0",
+        "@types/bun": "^1.3.14",
         "turbo": "^2.9.6",
       },
     },
@@ -294,6 +296,8 @@
 
     "@playground/web": ["@playground/web@workspace:apps/web"],
 
+    "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" }, "bin": { "playwright": "cli.js" } }, "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag=="],
+
     "@replit/codemirror-vim": ["@replit/codemirror-vim@6.3.0", "", { "peerDependencies": { "@codemirror/commands": "6.x.x", "@codemirror/language": "6.x.x", "@codemirror/search": "6.x.x", "@codemirror/state": "6.x.x", "@codemirror/view": "6.x.x" } }, "sha512-aTx931ULAMuJx6xLf7KQDOL7CxD+Sa05FktTDrtLaSy53uj01ll3Zf17JdKsriER248oS55GBzg0CfCTjEneAQ=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.17", "", { "os": "android", "cpu": "arm64" }, "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ=="],
@@ -412,6 +416,8 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
@@ -469,6 +475,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -900,6 +908,10 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
+
+    "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
+
     "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
@@ -1183,6 +1195,8 @@
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+	testDir: "./tests",
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: process.env.CI ? "github" : "list",
+	use: {
+		baseURL: "http://localhost:4173",
+		trace: "on-first-retry",
+	},
+	projects: [
+		{
+			name: "chromium",
+			use: { ...devices["Desktop Chrome"] },
+		},
+	],
+	webServer: {
+		command:
+			"bun --filter @playground/web build && bun --filter @playground/web preview --port 4173",
+		port: 4173,
+		reuseExistingServer: !process.env.CI,
+		cwd: "..",
+	},
+});

--- a/e2e/tests/playground.spec.ts
+++ b/e2e/tests/playground.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "@playwright/test";
+
+test("creates a package and runs hello world", async ({ page }) => {
+	test.setTimeout(120_000);
+
+	const packageName = `e2e_pkg_${Date.now()}`;
+
+	await page.goto("/");
+
+	await expect(page.getByTestId("wasm-loading")).toBeHidden({
+		timeout: 90_000,
+	});
+
+	const runButton = page.getByTestId("run-button");
+	await expect(runButton).toBeEnabled({ timeout: 10_000 });
+
+	await page.getByTestId("localspace-add").click();
+	await page.getByRole("menuitem", { name: "New Package" }).click();
+
+	const dialog = page.getByTestId("file-tree-dialog");
+	await expect(dialog).toBeVisible();
+	await dialog.getByLabel("Name").fill(packageName);
+	await dialog.getByRole("button", { name: "Create" }).click();
+	await expect(dialog).toBeHidden();
+
+	await expect(page.getByText(packageName)).toBeVisible();
+	await expect(runButton).toBeEnabled();
+
+	await runButton.click();
+	await expect(runButton).toContainText("[...]");
+	await expect(runButton).toContainText("Run", { timeout: 10_000 });
+
+	const output = page.getByTestId("output-pane");
+	await expect(output).toContainText("Hello, World!", { timeout: 10_000 });
+});

--- a/e2e/tests/playground.spec.ts
+++ b/e2e/tests/playground.spec.ts
@@ -31,5 +31,5 @@ test("creates a package and runs hello world", async ({ page }) => {
 	await expect(runButton).toContainText("Run", { timeout: 10_000 });
 
 	const output = page.getByTestId("output-pane");
-	await expect(output).toContainText("Hello, World!", { timeout: 10_000 });
+	await expect(output).toHaveText("Hello, World!", { timeout: 10_000 });
 });

--- a/package.json
+++ b/package.json
@@ -1,26 +1,30 @@
 {
 	"name": "@playground/monorepo",
-	"private": true,
-	"workspaces": {
-		"packages": [
-			"apps/*",
-			"packages/*"
-		]
+	"devDependencies": {
+		"@biomejs/biome": "^2.4.12",
+		"@playwright/test": "^1.60.0",
+		"@types/bun": "^1.3.14",
+		"turbo": "^2.9.6"
 	},
+	"packageManager": "bun@1.3.10",
+	"private": true,
 	"scripts": {
 		"dev": "turbo run dev",
 		"build": "turbo run build",
 		"preview": "turbo run preview",
 		"test": "turbo run test",
+		"test:e2e": "playwright test --config e2e/playwright.config.ts",
+		"test:e2e:ui": "playwright test --config e2e/playwright.config.ts --ui",
 		"format": "biome format . --write",
 		"lint": "biome check .",
 		"lint:fix": "biome check . --fix",
 		"clean": "git clean -xdf node_modules",
 		"clean:workspace": "turbo run clean"
 	},
-	"packageManager": "bun@1.3.10",
-	"devDependencies": {
-		"@biomejs/biome": "^2.4.12",
-		"turbo": "^2.9.6"
+	"workspaces": {
+		"packages": [
+			"apps/*",
+			"packages/*"
+		]
 	}
 }


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request adds end-to-end (E2E) testing infrastructure to the repository using Playwright, enabling automated testing of user workflows across the entire application stack.

## Changes

### Testing Infrastructure
- **Playwright Configuration**: Adds `e2e/playwright.config.ts` to configure Playwright for automated testing, targeting a locally running preview server (`http://localhost:4173`)
- **E2E Test Suite**: Introduces `e2e/tests/playground.spec.ts` with an initial test that verifies the core user flow of creating a package and executing code with expected output
- **Package Dependencies**: Adds `@playwright/test` and `@types/bun` to the project's development dependencies
- **Test Scripts**: Adds `test:e2e` and `test:e2e:ui` npm scripts for running tests in headless and interactive modes

### CI Integration
- **CI Workflow Updates**: Extends `.github/workflows/ci.yml` to install Playwright browser dependencies and execute the E2E test suite as part of the build-and-test job
- **Artifact Configuration**: Updates `.gitignore` to exclude test results and Playwright report artifacts from version control

### Component Instrumentation
- **Test Identifiers**: Adds `data-testid` attributes to UI components in:
  - `editor.tsx`: Output pane, run button, and WASM loading indicator
  - `app-sidebar.tsx`: Localspace action trigger button
  - `file-tree-dialog.tsx`: File tree dialog content
  
These identifiers enable reliable, maintainable element selection in automated tests.

## Outcome

The repository now has automated end-to-end testing capabilities that verify the application's core functionality works correctly across the full stack, improving confidence in releases and enabling continuous validation of user-facing features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/playground/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->