### PR TITLE
Add separate button for roadmap

### DIFF
--- a/apps/web/src/components/editor.tsx
+++ b/apps/web/src/components/editor.tsx
@@ -344,10 +344,11 @@ function EditorHeader() {
 					target="_blank"
 					rel="noopener noreferrer"
 				>
-					<span className="text-xs text-muted-foreground select-none">
-						{__BALLERINA_VERSION__}
-					</span>
+					<span>Roadmap</span>
 				</a>
+				<span className="text-xs text-muted-foreground select-none">
+					{__BALLERINA_VERSION__}
+				</span>
 				<SettingsDialog />
 			</div>
 		</header>


### PR DESCRIPTION
## Purpose
Separate out the roadmap button from version label as @pcnfernando requested.

<img width="203" height="62" alt="image" src="https://github.com/user-attachments/assets/afa9f451-e7ab-4742-95b5-a9535074f842" />
