### PR TITLE
Add e2e coverage for shared playground URLs

### DIFF
--- a/e2e/tests/playground.spec.ts
+++ b/e2e/tests/playground.spec.ts
@@ -1,4 +1,19 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+import type { Page } from "@playwright/test";
+
+async function runAndExpectOutput(page: Page, expectedOutput: string) {
+	const runButton = page.getByTestId("run-button");
+	await expect(runButton).toBeEnabled({ timeout: 10_000 });
+
+	await runButton.click();
+	await expect(runButton).toContainText("[...]");
+	await expect(runButton).toContainText("Run", { timeout: 10_000 });
+
+	await expect(page.getByTestId("output-pane")).toHaveText(expectedOutput, {
+		timeout: 10_000,
+	});
+}
 
 test("creates a package and runs hello world", async ({ page }) => {
 	test.setTimeout(120_000);
@@ -24,12 +39,35 @@ test("creates a package and runs hello world", async ({ page }) => {
 	await expect(dialog).toBeHidden();
 
 	await expect(page.getByText(packageName)).toBeVisible();
-	await expect(runButton).toBeEnabled();
 
-	await runButton.click();
-	await expect(runButton).toContainText("[...]");
-	await expect(runButton).toContainText("Run", { timeout: 10_000 });
+	await runAndExpectOutput(page, "Hello, World!");
+});
 
-	const output = page.getByTestId("output-pane");
-	await expect(output).toHaveText("Hello, World!", { timeout: 10_000 });
+const SHARE_PAYLOAD =
+	"H4sIAAAAAAAACnWQsWrDQBBEf%2BUylQ1CdtozaVKlNGl9Lk7SWl682j0uJ0MQ%2BvcgQZykSPuY2TfshGxW4CfcWDt4dJxRQeNA8OgzUWHtUaG9snSZFP70yF5Y6Cf8GkUos8a62CBLxbSQFnicUmxvsadzUMu9e3EBSeJnn23ULiDocmLFq3Ehd8ofbLrCff1c7wMwV%2F%2Boh8haN%2FGvlIdkubjme9aO7RA0aBob4dZdRm3LYljKm62bgjrnHJtPmbWIbgLeSMSeAraHoDPm81zBEuk7SSx8p2Ms119f2j1mzF%2FUrvUQVwEAAA%3D%3D";
+
+test("opens a shared package and runs it", async ({ page }) => {
+	test.setTimeout(120_000);
+
+	await page.goto(`/?share=${SHARE_PAYLOAD}`);
+
+	await expect(page.getByTestId("wasm-loading")).toBeHidden({
+		timeout: 90_000,
+	});
+
+	const sharedPackage = page
+		.getByRole("button", { name: "greeting" })
+		.locator("xpath=ancestor::li[1]");
+	await expect(sharedPackage).toBeVisible({ timeout: 10_000 });
+	await expect(
+		sharedPackage.locator('[data-sidebar="menu-button"]'),
+	).toHaveCount(3);
+	await expect(
+		sharedPackage.getByRole("button", { name: "Ballerina.toml" }),
+	).toBeVisible();
+	await expect(
+		sharedPackage.getByRole("button", { name: "main.bal" }),
+	).toBeVisible();
+
+	await runAndExpectOutput(page, "Hello!");
 });


### PR DESCRIPTION
## Purpose
Adds an end-to-end test that opens a shared Playground URL, runs the loaded code, and verifies the expected output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request extends end-to-end test coverage for shared Playground URLs. The changes introduce a reusable helper function to standardize output verification across tests, refactor existing test logic to use this helper for improved maintainability, and add new test coverage for the shared package functionality.

## Changes

**e2e/tests/playground.spec.ts**
- Introduced `runAndExpectOutput()` helper function to encapsulate the workflow of running code and verifying output, including UI state transitions (button enabled state, intermediate output display, and text updates)
- Refactored the existing "creates a package and runs hello world" test to use the new helper, reducing code duplication
- Added a new test case "opens a shared package and runs it" that validates the ability to load a shared Playground URL via query parameter, ensuring the shared package content appears correctly and executes with the expected output

**Lines changed:** +45/-7

<!-- end of auto-generated comment: release notes by coderabbit.ai -->