### PR TITLE
Fix OutputPane non-JSON outputs

### DIFF
--- a/apps/web/src/components/editor.tsx
+++ b/apps/web/src/components/editor.tsx
@@ -87,6 +87,21 @@ function findJsonFragmentEnd(text: string, start: number): number | null {
 	return null;
 }
 
+function isStandaloneJsonFragment(
+	text: string,
+	start: number,
+	end: number,
+): boolean {
+	const lineStart = text.lastIndexOf("\n", start - 1) + 1;
+	const nextLineBreak = text.indexOf("\n", end);
+	const lineEnd = nextLineBreak === -1 ? text.length : nextLineBreak;
+
+	return (
+		text.slice(lineStart, start).trim() === "" &&
+		text.slice(end, lineEnd).trim() === ""
+	);
+}
+
 function normalizeJsonValue(value: unknown): unknown {
 	if (typeof value === "string") {
 		const trimmed = value.trim();
@@ -141,6 +156,12 @@ function formatJsonOutput(output: string): string {
 
 			const end = findJsonFragmentEnd(output, cursor);
 			if (end === null) {
+				formatted += char;
+				cursor += 1;
+				continue;
+			}
+
+			if (!isStandaloneJsonFragment(output, cursor, end)) {
 				formatted += char;
 				cursor += 1;
 				continue;


### PR DESCRIPTION
## Purpose
Resolves #81
Depends #80 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated OutputPane JSON formatting so bracketed text embedded in normal console output is no longer mistaken for standalone JSON. The new helper checks whether a `{...}` or `[...]` fragment is isolated before formatting, preserving regular log lines like `[200] Files updated!` as-is and improving output rendering stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->