### PR TITLE
Add WASM service loopback dispatch

### DIFF
--- a/apps/web/src/components/editor.tsx
+++ b/apps/web/src/components/editor.tsx
@@ -482,6 +482,7 @@ function EditorContent() {
 		if (isRunning) return;
 		if (!activeFile || getLanguage(activeFile.path) !== "ballerina") return;
 
+		let isRunActive = true;
 		setIsRunning(true);
 		setListenerAddresses([]);
 		try {
@@ -492,9 +493,11 @@ function EditorContent() {
 			openOutputWith("");
 			await run(target, (event) => {
 				if (event.type === "output") appendOutput(event.text);
-				if (event.type === "listeners") setListenerAddresses(event.hosts);
+				if (event.type === "listeners" && isRunActive)
+					setListenerAddresses(event.hosts);
 			});
 		} finally {
+			isRunActive = false;
 			setIsRunning(false);
 			setListenerAddresses([]);
 		}

--- a/apps/web/src/workers/ballerina-worker-api.ts
+++ b/apps/web/src/workers/ballerina-worker-api.ts
@@ -19,7 +19,7 @@ export type RunEventCallback = (event: RunEvent) => void;
 
 export interface HttpDispatchRequest {
 	method?: string;
-	host?: string;
+	host: string;
 	path?: string;
 	query?: string;
 	headers?: Record<string, string | string[]>;

--- a/packages/wasm/http_wasm.go
+++ b/packages/wasm/http_wasm.go
@@ -6,6 +6,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"syscall/js"
 	"time"
@@ -30,22 +33,26 @@ func (ctx *requestContext) cleanup() {
 	}
 }
 
-func (c *fetchHTTPClient) Execute(ctx context.Context, method, url string, body io.Reader, _ int64, contentType string, reqHeaders map[string][]string) (int, map[string][]string, io.ReadCloser, error) {
-	fetch := js.Global().Get("fetch")
-	if !fetch.Truthy() {
-		return 0, nil, nil, fmt.Errorf("browser fetch API is not available")
-	}
-
+func (c *fetchHTTPClient) Execute(ctx context.Context, method, targetURL string, body io.Reader, _ int64, contentType string, reqHeaders map[string][]string) (int, map[string][]string, io.ReadCloser, error) {
 	bodyBytes, err := readRequestBody(method, body)
 	if err != nil {
 		return 0, nil, nil, err
+	}
+
+	if status, headers, respBody, handled, err := c.executeLocalRequest(ctx, method, targetURL, bodyBytes, contentType, reqHeaders); handled || err != nil {
+		return status, headers, respBody, err
+	}
+
+	fetch := js.Global().Get("fetch")
+	if !fetch.Truthy() {
+		return 0, nil, nil, fmt.Errorf("browser fetch API is not available")
 	}
 
 	reqCtx := &requestContext{}
 	defer reqCtx.cleanup()
 
 	options := c.buildFetchOptions(ctx, method, bodyBytes, contentType, reqHeaders, reqCtx)
-	resp, err := c.executeRequest(fetch, url, options)
+	resp, err := c.executeRequest(fetch, targetURL, options)
 	if err != nil {
 		return 0, nil, nil, err
 	}
@@ -60,6 +67,89 @@ func (c *fetchHTTPClient) Execute(ctx context.Context, method, url string, body 
 	}
 
 	return resp.Get("status").Int(), respHeaders, io.NopCloser(bytes.NewReader(respBody)), nil
+}
+
+func (c *fetchHTTPClient) executeLocalRequest(ctx context.Context, method, targetURL string, body []byte, contentType string, reqHeaders map[string][]string) (int, map[string][]string, io.ReadCloser, bool, error) {
+	parsed, err := url.Parse(targetURL)
+	if err != nil || !isLocalHTTPHost(parsed.Hostname()) {
+		return 0, nil, nil, false, err
+	}
+
+	handler, ok := localHandlerForHost(parsed)
+	if !ok {
+		return 0, nil, nil, true, fmt.Errorf("no in-memory service listening on %s", parsed.Host)
+	}
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	req, err := http.NewRequestWithContext(ctx, method, parsed.String(), bytes.NewReader(body))
+	if err != nil {
+		return 0, nil, nil, true, err
+	}
+	req.RequestURI = req.URL.RequestURI()
+	req.Host = parsed.Host
+	req.Header = http.Header{}
+	for key, values := range reqHeaders {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	req.ContentLength = int64(len(body))
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+	resp := recorder.Result()
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, nil, true, err
+	}
+	if c.cfg.ResponseLimits.MaxEntityBodySize != -1 && int64(len(respBody)) > c.cfg.ResponseLimits.MaxEntityBodySize {
+		return 0, nil, nil, true, fmt.Errorf("response entity body size exceeds: %d bytes", c.cfg.ResponseLimits.MaxEntityBodySize)
+	}
+
+	return resp.StatusCode, resp.Header, io.NopCloser(bytes.NewReader(respBody)), true, nil
+}
+
+func isLocalHTTPHost(host string) bool {
+	switch strings.ToLower(host) {
+	case "localhost", "127.0.0.1", "0.0.0.0", "::1":
+		return true
+	default:
+		return false
+	}
+}
+
+func localHandlerForHost(parsed *url.URL) (http.Handler, bool) {
+	if handler, ok := findLocalHandler(parsed); ok {
+		return handler, true
+	}
+	if activeRun.ensureStarted() {
+		return findLocalHandler(parsed)
+	}
+	return nil, false
+}
+
+func findLocalHandler(parsed *url.URL) (http.Handler, bool) {
+	candidates := []string{parsed.Host}
+	if port := parsed.Port(); port != "" {
+		candidates = append(candidates,
+			"0.0.0.0:"+port,
+			"localhost:"+port,
+			"127.0.0.1:"+port,
+		)
+	}
+	for _, candidate := range candidates {
+		if handler, ok := activeRun.getHandler(candidate); ok {
+			return handler, true
+		}
+	}
+	return nil, false
 }
 
 func readRequestBody(method string, body io.Reader) ([]byte, error) {

--- a/packages/wasm/http_wasm.go
+++ b/packages/wasm/http_wasm.go
@@ -75,9 +75,9 @@ func (c *fetchHTTPClient) executeLocalRequest(ctx context.Context, method, targe
 		return 0, nil, nil, false, err
 	}
 
-	handler, ok := localHandlerForHost(parsed)
+	handler, ok := findLocalHandler(parsed)
 	if !ok {
-		return 0, nil, nil, true, fmt.Errorf("no in-memory service listening on %s", parsed.Host)
+		return 0, nil, nil, false, nil
 	}
 
 	if ctx == nil {
@@ -123,16 +123,6 @@ func isLocalHTTPHost(host string) bool {
 	default:
 		return false
 	}
-}
-
-func localHandlerForHost(parsed *url.URL) (http.Handler, bool) {
-	if handler, ok := findLocalHandler(parsed); ok {
-		return handler, true
-	}
-	if activeRun.ensureStarted() {
-		return findLocalHandler(parsed)
-	}
-	return nil, false
 }
 
 func findLocalHandler(parsed *url.URL) (http.Handler, bool) {

--- a/packages/wasm/http_wasm.go
+++ b/packages/wasm/http_wasm.go
@@ -75,6 +75,7 @@ func (c *fetchHTTPClient) executeLocalRequest(ctx context.Context, method, targe
 		return 0, nil, nil, false, err
 	}
 
+	// Intentionally ignore the scheme for loopback requests; TLS is not supported.
 	handler, ok := findLocalHandler(parsed)
 	if !ok {
 		return 0, nil, nil, false, nil
@@ -128,7 +129,8 @@ func isLocalHTTPHost(host string) bool {
 func findLocalHandler(parsed *url.URL) (http.Handler, bool) {
 	candidates := []string{parsed.Host}
 	if port := parsed.Port(); port != "" {
-		candidates = append(candidates,
+		candidates = append(
+			candidates,
 			"0.0.0.0:"+port,
 			"localhost:"+port,
 			"127.0.0.1:"+port,

--- a/packages/wasm/listeners_wasm.go
+++ b/packages/wasm/listeners_wasm.go
@@ -3,72 +3,23 @@ package main
 import (
 	"ballerina-lang-go/platform/pal"
 	"context"
-	"fmt"
 	"net/http"
-	"sync"
 )
 
-var activeListeners = &listenerRegistry{
-	listeners: make(map[string]http.Handler),
+type wasmListenerHandle struct {
+	cfg pal.ServerConfig
 }
 
-type (
-	listenerRegistry struct {
-		mu        sync.RWMutex
-		listeners map[string]http.Handler
-	}
-	wasmListenerHandle struct {
-		cfg      pal.ServerConfig
-		registry *listenerRegistry
-	}
-)
-
 func (w *wasmListenerHandle) Close() error {
-	w.registry.unregister(w.cfg)
+	activeRun.unregisterListener(w.cfg)
 	return nil
 }
 
 func (w *wasmListenerHandle) Shutdown(ctx context.Context) error {
-	w.registry.unregister(w.cfg)
+	activeRun.unregisterListener(w.cfg)
 	return nil
 }
 
-func (r *listenerRegistry) register(cfg pal.ServerConfig, handler http.Handler) (pal.ServerHandle, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	host := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
-	if _, exists := r.listeners[host]; exists {
-		return nil, fmt.Errorf("listener already registered for host %s", host)
-	}
-	r.listeners[host] = handler
-	return &wasmListenerHandle{cfg: cfg, registry: r}, nil
-}
-
-func (r *listenerRegistry) unregister(cfg pal.ServerConfig) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	host := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
-	delete(r.listeners, host)
-}
-
-func (r *listenerRegistry) getHandler(host string) (http.Handler, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-	handler, ok := r.listeners[host]
-	return handler, ok
-}
-
-func (r *listenerRegistry) hosts() []any {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	hosts := make([]any, 0, len(r.listeners))
-	for host := range r.listeners {
-		hosts = append(hosts, host)
-	}
-	return hosts
-}
-
 func listen(cfg pal.ServerConfig, handler http.Handler) (pal.ServerHandle, error) {
-	return activeListeners.register(cfg, handler)
+	return activeRun.registerListener(cfg, handler)
 }

--- a/packages/wasm/main_wasm.go
+++ b/packages/wasm/main_wasm.go
@@ -72,14 +72,13 @@ func run(_ js.Value, args []js.Value) any {
 			done := func() { resolve.Invoke(js.Undefined()) }
 
 			signalSource, signals := newSignalSource()
-			defer signalSource.cleanup()
-
-			if !activateSignalSource(signalSource) {
+			if !activeRun.begin(signalSource) {
+				signalSource.cleanup()
 				fmt.Fprintf(stderr, "another Ballerina run is already active\n")
 				done()
 				return
 			}
-			defer deactivateSignalSource(signalSource)
+			defer activeRun.end(signalSource)
 
 			defer func() {
 				if r := recover(); r != nil {
@@ -125,16 +124,19 @@ func run(_ js.Value, args []js.Value) any {
 			workingDir := getWorkingDir(fsys, runPath)
 			pal := wasmPal(fsys, workingDir, stderr, stdout, signals)
 			rt := runtime.NewRuntime(pal, project.Environment().TypeEnv())
+			activeRun.setRuntime(signalSource, rt)
 			for _, birPkg := range birPkgs {
 				if err := rt.Init(*birPkg); err != nil {
 					fmt.Fprintf(stderr, "%v\n", err)
 					return
 				}
 			}
-			rt.Listen()
+			if !activeRun.isStarted() {
+				rt.Listen()
+			}
 			emitEvent(onEvent, map[string]any{
 				"type":  "listeners",
-				"hosts": activeListeners.hosts(),
+				"hosts": activeRun.hosts(),
 			})
 			_ = <-rt.ExitStatus
 		}()
@@ -142,7 +144,7 @@ func run(_ js.Value, args []js.Value) any {
 }
 
 func sendStopSignal(_ js.Value, _ []js.Value) any {
-	return sendSignal(pal.GracefulStop)
+	return activeRun.sendSignal(pal.GracefulStop)
 }
 
 func dispatchHttpRequest(_ js.Value, args []js.Value) any {
@@ -160,7 +162,7 @@ func dispatchHttpRequest(_ js.Value, args []js.Value) any {
 
 		reqObj := args[0]
 		host := getString(reqObj, "host", "")
-		handler, ok := activeListeners.getHandler(host)
+		handler, ok := activeRun.getHandler(host)
 		if !ok {
 			reject.Invoke(js.ValueOf(fmt.Sprintf("no service listening on %s", host)))
 			return

--- a/packages/wasm/main_wasm.go
+++ b/packages/wasm/main_wasm.go
@@ -131,9 +131,7 @@ func run(_ js.Value, args []js.Value) any {
 					return
 				}
 			}
-			if !activeRun.isStarted() {
-				rt.Listen()
-			}
+			activeRun.ensureStarted()
 			emitEvent(onEvent, map[string]any{
 				"type":  "listeners",
 				"hosts": activeRun.hosts(),

--- a/packages/wasm/main_wasm.go
+++ b/packages/wasm/main_wasm.go
@@ -159,16 +159,15 @@ func dispatchHttpRequest(_ js.Value, args []js.Value) any {
 		}
 
 		reqObj := args[0]
-		host := getString(reqObj, "host", "")
-		handler, ok := activeRun.getHandler(host)
-		if !ok {
-			reject.Invoke(js.ValueOf(fmt.Sprintf("no service listening on %s", host)))
-			return
-		}
-
 		req, err := httpRequestFromJS(reqObj)
 		if err != nil {
 			reject.Invoke(js.ValueOf(err.Error()))
+			return
+		}
+
+		handler, ok := findLocalHandler(req.URL)
+		if !ok {
+			reject.Invoke(js.ValueOf(fmt.Sprintf("no service listening on %s", req.Host)))
 			return
 		}
 

--- a/packages/wasm/run_context_wasm.go
+++ b/packages/wasm/run_context_wasm.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"ballerina-lang-go/platform/pal"
+	"ballerina-lang-go/runtime"
+	"fmt"
+	"net/http"
+	"sync"
+)
+
+var activeRun = &runContext{}
+
+type runContext struct {
+	mu sync.RWMutex
+
+	rt        *runtime.Runtime
+	signals   *signalSource
+	listeners map[string]http.Handler
+	started   bool
+}
+
+func (c *runContext) begin(signals *signalSource) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.signals != nil || c.rt != nil {
+		return false
+	}
+	c.signals = signals
+	c.listeners = make(map[string]http.Handler)
+	c.started = false
+	return true
+}
+
+func (c *runContext) end(signals *signalSource) {
+	c.mu.Lock()
+	if c.signals == signals {
+		c.rt = nil
+		c.signals = nil
+		c.listeners = nil
+		c.started = false
+	}
+	c.mu.Unlock()
+	signals.cleanup()
+}
+
+func (c *runContext) setRuntime(signals *signalSource, rt *runtime.Runtime) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.signals == signals {
+		c.rt = rt
+	}
+}
+
+func (c *runContext) ensureStarted() bool {
+	c.mu.Lock()
+	if c.rt == nil {
+		c.mu.Unlock()
+		return false
+	}
+	if c.started {
+		c.mu.Unlock()
+		return true
+	}
+	rt := c.rt
+	c.started = true
+	c.mu.Unlock()
+
+	rt.Listen()
+	return true
+}
+
+func (c *runContext) isStarted() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.started
+}
+
+func (c *runContext) sendSignal(sig pal.Signal) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.signals == nil {
+		return false
+	}
+	return c.signals.send(sig)
+}
+
+func (c *runContext) registerListener(cfg pal.ServerConfig, handler http.Handler) (pal.ServerHandle, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.listeners == nil {
+		return nil, fmt.Errorf("no active Ballerina run")
+	}
+	host := listenerHost(cfg)
+	if _, exists := c.listeners[host]; exists {
+		return nil, fmt.Errorf("listener already registered for host %s", host)
+	}
+	c.listeners[host] = handler
+	return &wasmListenerHandle{cfg: cfg}, nil
+}
+
+func (c *runContext) unregisterListener(cfg pal.ServerConfig) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.listeners, listenerHost(cfg))
+}
+
+func (c *runContext) getHandler(host string) (http.Handler, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	handler, ok := c.listeners[host]
+	return handler, ok
+}
+
+func (c *runContext) hosts() []any {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	hosts := make([]any, 0, len(c.listeners))
+	for host := range c.listeners {
+		hosts = append(hosts, host)
+	}
+	return hosts
+}
+
+func listenerHost(cfg pal.ServerConfig) string {
+	return fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
+}

--- a/packages/wasm/run_context_wasm.go
+++ b/packages/wasm/run_context_wasm.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"sort"
 	"sync"
 )
 
@@ -116,9 +117,15 @@ func (c *runContext) hosts() []any {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	hosts := make([]any, 0, len(c.listeners))
+	listenerHosts := make([]string, 0, len(c.listeners))
 	for host := range c.listeners {
-		hosts = append(hosts, host)
+		listenerHosts = append(listenerHosts, host)
+	}
+	sort.Strings(listenerHosts)
+
+	hosts := make([]any, len(listenerHosts))
+	for i, host := range listenerHosts {
+		hosts[i] = host
 	}
 	return hosts
 }

--- a/packages/wasm/run_context_wasm.go
+++ b/packages/wasm/run_context_wasm.go
@@ -4,6 +4,7 @@ import (
 	"ballerina-lang-go/platform/pal"
 	"ballerina-lang-go/runtime"
 	"fmt"
+	"net"
 	"net/http"
 	"sync"
 )
@@ -123,5 +124,5 @@ func (c *runContext) hosts() []any {
 }
 
 func listenerHost(cfg pal.ServerConfig) string {
-	return fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)
+	return net.JoinHostPort(cfg.Host, fmt.Sprintf("%d", cfg.Port))
 }

--- a/packages/wasm/signals_wasm.go
+++ b/packages/wasm/signals_wasm.go
@@ -1,14 +1,6 @@
 package main
 
-import (
-	"ballerina-lang-go/platform/pal"
-	"sync"
-)
-
-var (
-	activeSignalsMu sync.Mutex
-	activeSignals   *signalSource
-)
+import "ballerina-lang-go/platform/pal"
 
 type signalSource struct {
 	ch chan pal.Signal
@@ -30,31 +22,4 @@ func (s *signalSource) cleanup() {
 func newSignalSource() (*signalSource, pal.SignalSource) {
 	ch := make(chan pal.Signal, 2)
 	return &signalSource{ch: ch}, pal.SignalSource{Signals: ch}
-}
-
-func activateSignalSource(s *signalSource) bool {
-	activeSignalsMu.Lock()
-	defer activeSignalsMu.Unlock()
-	if activeSignals != nil {
-		return false
-	}
-	activeSignals = s
-	return true
-}
-
-func deactivateSignalSource(s *signalSource) {
-	activeSignalsMu.Lock()
-	defer activeSignalsMu.Unlock()
-	if activeSignals == s {
-		activeSignals = nil
-	}
-}
-
-func sendSignal(sig pal.Signal) bool {
-	activeSignalsMu.Lock()
-	defer activeSignalsMu.Unlock()
-	if activeSignals == nil {
-		return false
-	}
-	return activeSignals.send(sig)
 }


### PR DESCRIPTION
## Purpose
Resolves #85
Depends on #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds WASM-side HTTP loopback support for the playground so in-memory Ballerina services can receive requests without opening a real network listener.

Key changes:
- Introduces a new event-based run callback so the worker can emit both output and listener information.
- Adds a WASM HTTP dispatch path that routes loopback requests to the matching in-memory listener and returns the response directly.
- Updates the web UI to detect available listeners and provide a new “Send Request” panel for manually sending HTTP requests to them.
- Adds supporting UI primitives and form handling for tabs, select inputs, and request composition.
- Refactors the WASM runtime lifecycle to track the active run, register listeners, and support graceful stop handling.
- Updates tests and dependency metadata to align with the new request/response flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->