### PR TITLE
Add workflow for releasing main to live

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - live
 
 jobs:
   build-and-test:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,7 @@ name: Build and Deploy
 on:
   push:
     branches:
-      - main
-  workflow_dispatch:
+      - live
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Create Release PR
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  create-release-pr:
+    name: Create main to live release PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create release pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          pending_commits="$(gh api \
+            "repos/$GITHUB_REPOSITORY/compare/live...main" \
+            --jq '.ahead_by')"
+
+          if [ "$pending_commits" -eq 0 ]; then
+            echo "live already contains all commits from main; no release pull request was created." >&2
+            exit 1
+          fi
+
+          existing_pr="$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --base live \
+            --head main \
+            --state open \
+            --json url \
+            --jq '.[0].url')"
+
+          if [ -n "$existing_pr" ]; then
+            echo "A release pull request is already open: $existing_pr" >&2
+            exit 1
+          fi
+
+          gh pr create \
+            --repo "$GITHUB_REPOSITORY" \
+            --base live \
+            --head main \
+            --title "Deploy main to production" \
+            --body "Promotes the current main branch to the production (live) branch. Merging this PR deploys the Playground website."


### PR DESCRIPTION
## Purpose
Implements the branching and deployment approach proposed in ballerina-nutcracker/ballerina#632 discussion.

- Deploy GitHub Pages from `live`
- Run CI for PRs to `main` and `live`
- Add a manual workflow that creates a `main` → `live` production-release PR via `github-actions[bot]`
- Fail the release workflow when there are no commits to promote or a release PR is already open.

> [!IMPORTANT]
> Create the `live` branch from the current production commit before merging this PR. The release and deployment workflows require it.

Tested on a fork:

<img width="900" height="322" alt="image" src="https://github.com/user-attachments/assets/a4c0cb50-769d-4b0c-8112-1f5f491cfc12" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `live` as a CI pull request target.
- Updated GitHub Pages deployment to publish from `live`.
- Added a manually triggered workflow to create release pull requests from `main` to `live`, avoiding duplicates and failing when no changes are pending or a release PR already exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
