### PR TITLE
Make the Run button clearly identifiable using the Ballerina brand teal

### DIFF
--- a/apps/web/src/components/editor.tsx
+++ b/apps/web/src/components/editor.tsx
@@ -318,8 +318,8 @@ function EditorPane({
 					{activeFile ? basename(activeFile.path) : "No file selected"}
 				</span>
 				<Button
-					className="h-full"
-					variant="ghost"
+					className="h-full px-4"
+					variant={isRunning ? "ghost" : "brand"}
 					data-testid="run-button"
 					onClick={isRunning ? () => void onStop() : () => void onRun()}
 					disabled={

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -9,6 +9,8 @@ const buttonVariants = cva(
 		variants: {
 			variant: {
 				default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+				brand:
+					"bg-brand text-brand-foreground hover:bg-brand/90 focus-visible:ring-brand/40",
 				outline:
 					"border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground",
 				secondary:

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
 			variant: {
 				default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
 				brand:
-					"bg-brand text-brand-foreground hover:bg-brand/90 focus-visible:ring-brand/40",
+					"border-brand text-brand hover:bg-brand/10 focus-visible:ring-brand/40",
 				outline:
 					"border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground",
 				secondary:

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -16,7 +16,6 @@
 	--primary-foreground: oklch(0.985 0 0);
 	/* Ballerina brand teal — used for the primary "Run" action. */
 	--brand: #20b6b0;
-	--brand-foreground: #ffffff;
 	--secondary: oklch(0.97 0 0);
 	--secondary-foreground: oklch(0.205 0 0);
 	--muted: oklch(0.97 0 0);
@@ -71,7 +70,6 @@
 	--primary-foreground: oklch(0.205 0 0);
 	/* Ballerina brand teal — used for the primary "Run" action. */
 	--brand: #20b6b0;
-	--brand-foreground: #ffffff;
 	--secondary: oklch(0.269 0 0);
 	--secondary-foreground: oklch(0.985 0 0);
 	--muted: oklch(0.269 0 0);
@@ -141,7 +139,6 @@
 	--color-secondary: var(--secondary);
 	--color-primary-foreground: var(--primary-foreground);
 	--color-primary: var(--primary);
-	--color-brand-foreground: var(--brand-foreground);
 	--color-brand: var(--brand);
 	--color-popover-foreground: var(--popover-foreground);
 	--color-popover: var(--popover);

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -14,6 +14,9 @@
 	--popover-foreground: oklch(0.145 0 0);
 	--primary: oklch(0.205 0 0);
 	--primary-foreground: oklch(0.985 0 0);
+	/* Ballerina brand teal — used for the primary "Run" action. */
+	--brand: #20b6b0;
+	--brand-foreground: #ffffff;
 	--secondary: oklch(0.97 0 0);
 	--secondary-foreground: oklch(0.205 0 0);
 	--muted: oklch(0.97 0 0);
@@ -66,6 +69,9 @@
 	--popover-foreground: oklch(0.985 0 0);
 	--primary: oklch(0.87 0 0);
 	--primary-foreground: oklch(0.205 0 0);
+	/* Ballerina brand teal — used for the primary "Run" action. */
+	--brand: #20b6b0;
+	--brand-foreground: #ffffff;
 	--secondary: oklch(0.269 0 0);
 	--secondary-foreground: oklch(0.985 0 0);
 	--muted: oklch(0.269 0 0);
@@ -135,6 +141,8 @@
 	--color-secondary: var(--secondary);
 	--color-primary-foreground: var(--primary-foreground);
 	--color-primary: var(--primary);
+	--color-brand-foreground: var(--brand-foreground);
+	--color-brand: var(--brand);
 	--color-popover-foreground: var(--popover-foreground);
 	--color-popover: var(--popover);
 	--color-card-foreground: var(--card-foreground);


### PR DESCRIPTION
## Purpose

The **Run** button was `variant="ghost"`, so it rendered as plain text in the editor toolbar with no fill or border.

This became a real usability problem while embedding the playground on the upcoming `ballerina.io/nutcracker` landing page: in informal testing, people **did not realise the embedded playground was runnable at all** — several read the whole editor as a static screenshot or GIF. The `Run` control simply did not look like a control.

## Goals

Make Run read unambiguously as the primary action, using the Ballerina brand teal so it is consistent with `ballerina.io` — without making the toolbar loud.

## Approach

Rather than hardcoding a colour in the component, this follows the existing design-system pattern:

1. **`styles.css`** — adds a `--brand` token to both `:root` and `.dark`, mapped through `@theme inline` as `--color-brand`.

   Worth noting: the theme previously had **no brand colour at all** (`--primary` is neutral `oklch(0.205 0 0)`), so this introduces the brand as a proper token that other actions can reuse.

2. **`button.tsx`** — adds a reusable `brand` variant:
   `border-brand text-brand hover:bg-brand/10 focus-visible:ring-brand/40`

3. **`editor.tsx`** — Run uses `variant="brand"` and gains `px-4` for presence. **Stop deliberately stays `ghost`**, so a running program is not signalled with a "go" colour.

### Before

Text-only — no border, no fill. Easy to miss entirely.

![Run button before](https://raw.githubusercontent.com/ballerina-nutcracker/playground/assets/pr-105-screenshots/pr-105/run-button-before.png)

### After

Teal border and label, with a faint teal tint on hover.

![Run button after](https://raw.githubusercontent.com/ballerina-nutcracker/playground/assets/pr-105-screenshots/pr-105/run-button-after.png)

In context:

![Editor with the updated Run button](https://raw.githubusercontent.com/ballerina-nutcracker/playground/assets/pr-105-screenshots/pr-105/editor-after.png)

An earlier revision of this PR used a solid teal fill. That was too heavy for this minimal, monochrome UI, so it was changed to the outlined treatment. Square corners are kept so the button matches the surrounding `rounded-none` design language.

> Screenshots are hosted on the `assets/pr-105-screenshots` branch to keep binaries out of this diff. That branch can be deleted once this PR is merged.

### Notes for the reviewer

- **Colour format.** The rest of `styles.css` uses `oklch`, but converting `#20b6b0` lands on `rgb(31,182,176)` — off by 1/255. The literal brand hex is used so the colour is exact and self-documenting. Happy to switch to `oklch(0.703 0.116 190.6)` if format consistency is preferred.
- **Contrast, for transparency.** `#20b6b0` against white measures **2.51:1** — below the 3:1 WCAG 1.4.11 asks for UI component boundaries, and below 4.5:1 for text. Note this is unchanged by using an outline instead of a fill: contrast is a ratio between the two colours, so swapping foreground and background does not affect it. It matches how `ballerina.io` uses this teal today, so it was kept for brand consistency; a darker teal would be needed to reach AA if you would rather prioritise that.

## Release note

The Run button in the playground editor is now outlined in the Ballerina brand teal, making it clearly identifiable as the primary action.

## Documentation

N/A — visual change to an existing control, no documented behaviour changes.

## Automation tests

- Unit tests: none added — this is a styling change. The existing `data-testid="run-button"` hook is unchanged, so current tests and e2e selectors continue to work.
- Integration tests: N/A

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend styling change)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
