### PR TITLE
Support collapsing the sidebar via a ?sidebar=collapsed URL parameter

### DIFF
--- a/apps/web/src/components/editor.tsx
+++ b/apps/web/src/components/editor.tsx
@@ -670,9 +670,13 @@ function WasmLoadingScreen({
 	);
 }
 
-export function Editor() {
+export function Editor({
+	defaultSidebarOpen = true,
+}: {
+	defaultSidebarOpen?: boolean;
+}) {
 	return (
-		<SidebarProvider>
+		<SidebarProvider defaultOpen={defaultSidebarOpen}>
 			<EditorContent />
 		</SidebarProvider>
 	);

--- a/apps/web/src/components/file-route-sync.tsx
+++ b/apps/web/src/components/file-route-sync.tsx
@@ -73,6 +73,7 @@ export function FileRouteSync({ children }: React.PropsWithChildren) {
 				navigate({
 					to: "/$",
 					params: { _splat: DEFAULT_SPLAT },
+					search: true,
 					replace: true,
 				});
 			}
@@ -100,7 +101,12 @@ export function FileRouteSync({ children }: React.PropsWithChildren) {
 
 		if (expectedSplat !== currentSplat) {
 			if (!activeFilePath) clearedByDeletionRef.current = true;
-			navigate({ to: "/$", params: { _splat: expectedSplat }, replace: true });
+			navigate({
+				to: "/$",
+				params: { _splat: expectedSplat },
+				search: true,
+				replace: true,
+			});
 		}
 	}, [ready, isProcessingShare, activeFilePath, currentSplat, navigate]);
 

--- a/apps/web/src/routes/$.tsx
+++ b/apps/web/src/routes/$.tsx
@@ -6,21 +6,37 @@ import { FSProvider } from "@/providers/fs-provider";
 import { FileRouteSync } from "@/components/file-route-sync";
 import { Editor } from "@/components/editor";
 
+type PlaygroundSearch = {
+	share?: string;
+	sidebar?: "collapsed";
+};
+
 export const Route = createFileRoute("/$")({
-	validateSearch: (search: Record<string, unknown>) => {
+	validateSearch: (search: Record<string, unknown>): PlaygroundSearch => {
+		const validated: PlaygroundSearch = {};
+
 		const share = search.share;
-		if (typeof share !== "string" || !share.trim()) return {};
-		return { share: share.trim() };
+		if (typeof share === "string" && share.trim()) {
+			validated.share = share.trim();
+		}
+
+		if (search.sidebar === "collapsed") {
+			validated.sidebar = "collapsed";
+		}
+
+		return validated;
 	},
 	component: SplatComponent,
 });
 
 function SplatComponent() {
+	const { sidebar } = Route.useSearch();
+
 	return (
 		<FSProvider>
 			<BallerinaProvider>
 				<FileRouteSync>
-					<Editor />
+					<Editor defaultSidebarOpen={sidebar !== "collapsed"} />
 				</FileRouteSync>
 			</BallerinaProvider>
 		</FSProvider>


### PR DESCRIPTION
## Purpose

When the playground is embedded in another page, the **Examples** sidebar is usually not wanted — the host page has already chosen the example it wants to show, and the file list is noise (and invites the reader away from the page).

There is currently no way to ask for that. While embedding the playground on the upcoming `ballerina.io/nutcracker` landing page, the only option was to crop the iframe with CSS:

```css
/* what embedders have to do today */
width: calc(100% + 288px);
margin-left: -288px;   /* shift the 18rem sidebar out of view */
overflow: hidden;
```

That is brittle in a few ways:

- it hardcodes the sidebar's `18rem` width, so it silently breaks if that ever changes;
- a stray click on the sidebar toggle (or <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>B</kbd>) collapses the sidebar and leaves a 288px gap;
- while the WASM runtime boots there is no sidebar yet, so the boot screen — which centres itself on the iframe — appears visibly off-centre in the host's frame.

## Goals

Let an embedder ask for a collapsed sidebar directly, so no CSS cropping is needed.

## Approach

Accept an optional `sidebar` search parameter on the playground route and use it to seed `SidebarProvider`'s existing `defaultOpen` prop:

```
https://play.ballerina.io/tmp/examples/02-http-client.bal?sidebar=collapsed
```

- `Editor` takes a `defaultSidebarOpen` prop (defaults to `true`), so **behaviour is unchanged unless the parameter is passed**.
- Only the *initial* state is affected — the sidebar can still be opened with the toggle or <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>B</kbd>.
- `SidebarProvider` only ever *writes* the `sidebar_state` cookie and never reads it, so the parameter is not fighting any persisted value.

This also fixes a small pre-existing bug in `validateSearch`: it returned `{}` early when `share` was absent, which would have dropped any other parameter. It now accumulates the parameters it recognises.

### Default (unchanged)

![Playground with the sidebar, default behaviour](https://raw.githubusercontent.com/ballerina-nutcracker/playground/assets/pr-105-screenshots/pr-106/sidebar-default.png)

### With `?sidebar=collapsed`

The editor and output panes take the full width — no cropping needed by the host page.

![Playground with the sidebar collapsed via the URL parameter](https://raw.githubusercontent.com/ballerina-nutcracker/playground/assets/pr-105-screenshots/pr-106/sidebar-collapsed.png)

> These shots are taken from `main`, so the Run button still shows its current `ghost` styling — the teal Run button is a separate change in #105. The two PRs are independent.
>
> Screenshots are hosted on the `assets/pr-105-screenshots` branch to keep binaries out of this diff. That branch can be deleted once both PRs are merged.

## Release note

The playground can now be embedded with its Examples sidebar initially collapsed by adding `?sidebar=collapsed` to the URL.

## Documentation

N/A — happy to add a short note to the README about embedding options if you would like one.

## Automation tests

- Unit tests: none added — the change is a prop passed through to an existing component. Default behaviour is covered by the existing suite, since `defaultSidebarOpen` defaults to `true`.
- Integration tests: N/A. `tsc -b` and `biome check` both pass.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? N/A (frontend change). The parameter is strictly validated against a single literal value and is never interpolated anywhere.
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for opening the editor with its sidebar collapsed.
  * Added URL support for controlling the initial sidebar state.
  * Preserved valid shared-content links alongside sidebar settings.

* **Bug Fixes**
  * Improved URL parameter validation by trimming empty share values.
  * Restricted sidebar settings to supported values for more reliable navigation.
  * Preserved sidebar and sharing settings when navigating between files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->