### PR TITLE
fix: preserve empty query and header values

### DIFF
--- a/apps/web/src/components/try-it-panel.tsx
+++ b/apps/web/src/components/try-it-panel.tsx
@@ -217,7 +217,7 @@ function buildHeaderRecord(
 	for (const entry of entries) {
 		const key = entry.key.trim();
 		const value = entry.value.trim();
-		if (!key || !value) continue;
+		if (!key) continue;
 
 		const existing = headers[key];
 		if (Array.isArray(existing)) {
@@ -237,7 +237,7 @@ function buildQueryString(url: URL, entries: KeyValueEntry[]) {
 	for (const entry of entries) {
 		const key = entry.key.trim();
 		const value = entry.value.trim();
-		if (!key || !value) continue;
+		if (!key) continue;
 		params.append(key, value);
 	}
 


### PR DESCRIPTION
## Purpose
$subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved query parameters with empty values when constructing request headers and URLs.
  * Only parameters with empty keys are now omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->