### PR TITLE
fix: preserve whitespace in query and header values

### DIFF
--- a/apps/web/src/components/try-it-panel.tsx
+++ b/apps/web/src/components/try-it-panel.tsx
@@ -216,7 +216,7 @@ function buildHeaderRecord(
 	const headers: Record<string, string | string[]> = {};
 	for (const entry of entries) {
 		const key = entry.key.trim();
-		const value = entry.value.trim();
+		const value = entry.value;
 		if (!key) continue;
 
 		const existing = headers[key];
@@ -236,7 +236,7 @@ function buildQueryString(url: URL, entries: KeyValueEntry[]) {
 	const params = new URLSearchParams(url.search);
 	for (const entry of entries) {
 		const key = entry.key.trim();
-		const value = entry.value.trim();
+		const value = entry.value;
 		if (!key) continue;
 		params.append(key, value);
 	}


### PR DESCRIPTION
## Purpose
Resolves #111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved leading and trailing whitespace in header and query parameter values when sending requests.
  * Continued trimming whitespace from parameter names for consistent request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->