### PR TITLE
fix: prevent duplicate stop signals

### DIFF
--- a/apps/web/src/workers/ballerina-worker.ts
+++ b/apps/web/src/workers/ballerina-worker.ts
@@ -111,7 +111,9 @@ const api: BallerinaWorkerAPI = {
 			throw new Error("Ballerina runtime is not initialized");
 		const stopped = await self.sendStopSignal();
 		if (!stopped)
-			throw new Error("No running Ballerina program accepted the stop signal");
+			throw new Error(
+				"The Ballerina program is already stopping or has stopped.",
+			);
 	},
 	dispatchHttpRequest: async (request) => {
 		if (typeof self.dispatchHttpRequest !== "function")

--- a/e2e/tests/listeners.spec.ts
+++ b/e2e/tests/listeners.spec.ts
@@ -27,3 +27,25 @@ test("runs a listener and stops", async ({ page }) => {
 		},
 	);
 });
+
+test("ignores repeated stop requests", async ({ page }) => {
+	const playground = new PlaygroundPage(page);
+	const listenerCode = await loadFixture("listener.bal");
+	const packageName = `e2e_listener_stops_${Date.now()}`;
+
+	await playground.open();
+	await playground.createPackage(packageName);
+	await playground.replaceEditorContent(listenerCode);
+	await playground.start();
+	await expect(playground.runButton).toHaveText("Stop", { timeout: 10_000 });
+
+	await playground.runButton.evaluate((button) => {
+		(button as HTMLElement).click();
+		(button as HTMLElement).click();
+	});
+	await expect(playground.runButton).toHaveText("Run", { timeout: 10_000 });
+
+	await playground.start();
+	await expect(playground.runButton).toHaveText("Stop", { timeout: 10_000 });
+	await playground.stop();
+});

--- a/packages/wasm/main_wasm.go
+++ b/packages/wasm/main_wasm.go
@@ -74,7 +74,7 @@ func run(_ js.Value, args []js.Value) any {
 			signalSource, signals := newSignalSource()
 			if !activeRun.begin(signalSource) {
 				signalSource.cleanup()
-				fmt.Fprintf(stderr, "another Ballerina run is already active\n")
+				fmt.Fprintf(stderr, "A Ballerina program is already running.\n")
 				done()
 				return
 			}

--- a/packages/wasm/signals_wasm.go
+++ b/packages/wasm/signals_wasm.go
@@ -1,14 +1,28 @@
 package main
 
-import "ballerina/platform/pal"
+import (
+	"ballerina/platform/pal"
+	"sync"
+)
 
 type signalSource struct {
-	ch chan pal.Signal
+	mu sync.Mutex
+
+	ch             chan pal.Signal
+	stopSignalSent bool
+	closed         bool
 }
 
 func (s *signalSource) send(sig pal.Signal) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed || s.stopSignalSent {
+		return false
+	}
+
 	select {
 	case s.ch <- sig:
+		s.stopSignalSent = true
 		return true
 	default:
 		return false
@@ -16,10 +30,16 @@ func (s *signalSource) send(sig pal.Signal) bool {
 }
 
 func (s *signalSource) cleanup() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.closed = true
 	close(s.ch)
 }
 
 func newSignalSource() (*signalSource, pal.SignalSource) {
-	ch := make(chan pal.Signal, 2)
+	ch := make(chan pal.Signal, 1)
 	return &signalSource{ch: ch}, pal.SignalSource{Signals: ch}
 }

--- a/packages/wasm/signals_wasm.go
+++ b/packages/wasm/signals_wasm.go
@@ -8,25 +8,21 @@ import (
 type signalSource struct {
 	mu sync.Mutex
 
-	ch             chan pal.Signal
-	stopSignalSent bool
-	closed         bool
+	ch            chan pal.Signal
+	stopRequested bool
+	closed        bool
 }
 
 func (s *signalSource) send(sig pal.Signal) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.closed || s.stopSignalSent {
+	if s.closed || s.stopRequested {
 		return false
 	}
 
-	select {
-	case s.ch <- sig:
-		s.stopSignalSent = true
-		return true
-	default:
-		return false
-	}
+	s.ch <- sig
+	s.stopRequested = true
+	return true
 }
 
 func (s *signalSource) cleanup() {


### PR DESCRIPTION
## Purpose
Resolves #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when attempting to start a program that is already running or stop one that is already stopping or stopped.
  * Repeated stop requests are now handled safely without disrupting the active listener.
  * Listeners can be restarted and stopped normally after repeated stop attempts.
  * Improved run and stop signal handling to prevent duplicate or invalid requests from causing unexpected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->