### PR TITLE
feat: print a progress message before fetching packages in http client sample

### DIFF
--- a/e2e/fixtures/examples/02-http-client.txt
+++ b/e2e/fixtures/examples/02-http-client.txt
@@ -1,3 +1,4 @@
+Fetching popular packages for query 'aws' from Ballerina Central...
 Top <number> popular packages for query 'aws':
 <package> (<number> pulls)
 <package> (<number> pulls)

--- a/examples/02-http-client/main.bal
+++ b/examples/02-http-client/main.bal
@@ -15,6 +15,8 @@ type SearchResult record {
 public function main() returns error? {
     string query = "aws";
     http:Client registry = check new ("https://api.central.ballerina.io/2.0/registry");
+
+    io:println(string `Fetching popular packages for query '${query}' from Ballerina Central...`);
     http:Response res = check registry->get(string `/packages?q=${query}&limit=50`);
     SearchResult result = check (check res.getJsonPayload()).fromJsonWithType();
 


### PR DESCRIPTION
> $Subject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Added a status message indicating that popular packages are being fetched from Ballerina Central before displaying query results.
  * The message includes the search query and registry name for clearer feedback during requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->